### PR TITLE
fix reply in posts

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -40,7 +40,7 @@
 		<% if user_signed_in? && post.kind == 'first' && post.topic.forum.allow_post_voting == true %>
 			<div class="add-form inline-reply">
 			<h4><%= t(:reply) %></h4>
-			<%= bootstrap_form_for :post, :url => topic_posts_path(@topic) do |f| -%>
+			<%= bootstrap_form_for :post, :url => topic_posts_path(@topic), :remote => true do |f| -%>
 			  <%= f.text_area :body, :rows => 4, :cols => 160, label: 'Type your response:' -%></p>
 			  <%= f.hidden_field 'kind', value: 'reply' %>
 				<div class="add-screenshots">

--- a/app/views/posts/create.js.erb
+++ b/app/views/posts/create.js.erb
@@ -2,7 +2,7 @@ $('#posts').append('<%= j render(partial: 'post', locals: { post: @post }) %>');
 
 // Update timestamps
 $('.last-active time[data-time-ago]').timeago();
-
+$('.profile').initial();
 // jQuery hook
 //Helpy.ready();
 //Helpy.track();

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -5,9 +5,9 @@
 			Helpy.messages = '<%= j t(:collapsed_messages, count: @posts.count-2) %>';
 		</script>
 
-		<table id="posts">
+		<div id="posts">
 			<%= render :partial => 'post', :collection => @posts %>
-		</table>
+		</div>
 
 		<%
 		# NOTE: this is a bit of confusing logic- basically if the forum does not

--- a/app/views/posts/up_vote.js.erb
+++ b/app/views/posts/up_vote.js.erb
@@ -1,5 +1,6 @@
 <% if user_signed_in? %>
 $('#post-<%= @post.id %>').replaceWith("<%= j(render partial: 'posts/post', locals: {post: @post}) %>");
+$('.profile').initial();
 <% else %>
 $('.login-link').click();
 <% end %>


### PR DESCRIPTION
fix #79 
```$('.profile').initial();``` - reinitialize avatar
```<div id="posts">``` - valid markup, there is now rows in table, so posts are not wrapped in table#posts( see page source before this commit in chrome), so replace table with div.
