### PR TITLE
Add griddler-sparkpost for SparkPost integration.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,7 @@ gem 'griddler-sendgrid'
 gem 'griddler-mailgun'
 gem 'griddler-postmark'
 gem 'griddler-mailin'
+gem 'griddler-sparkpost
 
 gem 'rails-timeago'
 

--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ gem 'griddler-sendgrid'
 gem 'griddler-mailgun'
 gem 'griddler-postmark'
 gem 'griddler-mailin'
-gem 'griddler-sparkpost
+gem 'griddler-sparkpost'
 
 gem 'rails-timeago'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,9 @@ GEM
       griddler
     haml (4.0.7)
       tilt
+    griddler-sparkpost (0.0.1)
+      griddler
+      mail
     hashie (3.4.3)
     highline (1.7.8)
     hitimes (1.2.3)
@@ -490,6 +493,7 @@ DEPENDENCIES
   griddler-mandrill
   griddler-postmark
   griddler-sendgrid
+  griddler-sparkpost
   http_accept_language
   i18n-country-translations
   jbuilder (~> 2.0)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,7 +26,7 @@ admin_email: inbound.support@yourdomain.com
 from_email: inbound.support@yourdomain.com # This is the email that will be used for email replies (reply to)
 send_email: true #Send email or not
 
-mail_service: :mandrill # :sendgrid :cloudmailin, :postmark, :mandrill, :mailgun
+mail_service: :mandrill # :sendgrid :cloudmailin, :postmark, :mandrill, :mailgun, :sparkpost
 smtp_mail_username: # Enter your SMTP email username
 smtp_mail_password: # Enter your SMTP email password
 mail_smtp: 'smtp.mandrillapp.com' #Enter the server address for your SMTP server


### PR DESCRIPTION
Sparkpost is a populair mailservice after Mandrill has announced their Mailchimp merge, so it would make sense to add it by default. Tested it and works on my installation