### PR TITLE
change key :i18n in locales to :international

### DIFF
--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -11,7 +11,7 @@
       <div class="row" data-hook="admin_settings_grid">
         <%= settings_item('glyphicon glyphicon-cog', "general", "Manage general system settings like your Helpy name, what company to link back to.") %>
         <%= settings_item('glyphicon glyphicon-pencil', "design", "Control the logos and colors and other design aspects of your Helpy") %>
-        <%= settings_item('glyphicon glyphicon-globe', "i18n", "Select what languages your Helpy will speak be able to speak.") %>
+        <%= settings_item('glyphicon glyphicon-globe', "international", "Select what languages your Helpy will speak be able to speak.") %>
         <%= settings_item('glyphicon glyphicon-modal-window', "widget", "Find out how to deploy the Helpy widget on your site.") %>
         <%= settings_item('glyphicon glyphicon-envelope', "email", "Set up SMTP and Inbound email for your Helpy.") %>
         <%= settings_item('glyphicon glyphicon-cloud', "cloudinary", "Set up Cloudinary to enable your Helpy to accept image attachments.") %>
@@ -24,7 +24,7 @@
     <ul class="settings-menu list-unstyled" data-hook="admin_settings_menu">
       <%= settings_menu_item('glyphicon glyphicon-cog', 'general') %>
       <%= settings_menu_item('glyphicon glyphicon-pencil', 'design') %>
-      <%= settings_menu_item('glyphicon glyphicon-globe', 'i18n') %>
+      <%= settings_menu_item('glyphicon glyphicon-globe', 'international') %>
       <%= settings_menu_item('glyphicon glyphicon-modal-window', 'widget') %>
       <%= settings_menu_item('glyphicon glyphicon-envelope', 'email') %>
       <%= settings_menu_item('glyphicon glyphicon-cloud', 'cloudinary') %>
@@ -71,7 +71,7 @@
         <%= f.text_field 'css.form_background', value: AppSettings['css.form_background'], label: "Add Form Background", class: 'pick-a-color' %>
         <%= f.text_field 'css.still_need_help', value: AppSettings['css.still_need_help'], label: "Still Need Help Background", class: 'pick-a-color' %>
       </div>
-      <div class="settings-section i18n hidden" data-hook="admin_settings_i18n">
+      <div class="settings-section international hidden" data-hook="admin_settings_international">
         Supported Locales:
         <% I18n.available_locales.each do |locale| %>
           <%= f.check_box 'i18n.available_locales', { multiple: true, label: I18n.translate("language_name", locale: locale.to_s), checked: AppSettings['i18n.available_locales'].include?(locale.to_s) }, "#{locale}", nil  %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -205,7 +205,7 @@ en:
   settings: "Settings"
   general: "General"
   design: "Design"
-  i18n: "International"
+  international: "International"
   widget: "Embeddable Widget"
 
   activerecord:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -205,7 +205,7 @@ tr:
   settings: "Ayarlar: Genel"
   general: "Genel"
   design: "Dizayn"
-  i18n: "Uluslararası"
+  international: "Uluslararası"
   widget: "Gömülebilir Bileşen"
 
   activerecord:


### PR DESCRIPTION
There were some problems with this key, cuz some of rails-i18n files create this key.
E.g. https://github.com/svenfuchs/rails-i18n/blob/master/lib/rails_i18n/common_pluralizations/east_slavic.rb

see [this issue](https://github.com/helpyio/helpy/issues/151)