### PR TITLE
Handle no email from Oauth, Fixes #170, Fixes #126

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -26,7 +26,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     # their email address and then returned to the home page
 
     @user = user
-    if !env['omniauth.auth'].email.present? && !@user.email.present?
+    if !env['omniauth.auth'].email.present? && @user.email == @user.temp_email(env['omniauth.auth'])
       # @user = user
       render "users/finish_signup"
     else

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -17,9 +17,21 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   private
 
   def handle_redirect(_session_variable, _kind)
+
     # Use the session locale set earlier; use the default if it isn't available.
     I18n.locale = session[:omniauth_login_locale] || I18n.default_locale
-    sign_in_and_redirect user#, event: :authentication
+
+    # NOTE: This is for oauth users without email addresses.  This means twitter
+    # and sometimes github and facebook for sure.  They are redirected to add
+    # their email address and then returned to the home page
+
+    @user = user
+    if !env['omniauth.auth'].email.present? && !@user.email.present?
+      # @user = user
+      render "users/finish_signup"
+    else
+      sign_in_and_redirect user#, event: :authentication
+    end
   end
 
   def user

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -22,13 +22,17 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     I18n.locale = session[:omniauth_login_locale] || I18n.default_locale
 
     # NOTE: This is for oauth users without email addresses.  This means twitter
-    # and sometimes github and facebook for sure.  They are redirected to add
+    # and sometimes github and facebook.  They are redirected to add
     # their email address and then returned to the home page
 
     @user = user
     if !env['omniauth.auth'].email.present? && @user.email == @user.temp_email(env['omniauth.auth'])
       # @user = user
-      render "users/finish_signup"
+      session['omniauth_uid'] = env['omniauth.auth'].uid
+
+      @page_title = "Please complete your signup"
+      # render "users/finish_signup"
+      redirect_to finish_signup_path
     else
       sign_in_and_redirect user#, event: :authentication
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,11 +1,14 @@
 class UsersController < ApplicationController
   before_action :set_user
+  before_action :check_auth
 
   # NOTE: This is for oauth users without email addresses.  This means twitter
-  # and sometimes github and facebook for sure.
+  # and sometimes github and facebook.
 
   # GET/PATCH /users/:id/finish_signup
   def finish_signup
+    @page_title = "Please complete your signup"
+
     if request.patch? && params[:user] #&& params[:user][:email]
       if @user.update(user_params)
         # @user.skip_reconfirmation!
@@ -13,17 +16,23 @@ class UsersController < ApplicationController
         redirect_to root_path, notice: 'Your profile was successfully updated.'
       else
         @show_errors = true
+        render
       end
     end
   end
 
   private
+
+    def check_auth
+      redirect_to new_user_session_path unless session['omniauth_uid'].present?
+    end
+
     def set_user
-      @user = User.find(params[:id])
+      @user = User.where('uid = ?', session['omniauth_uid']).first
     end
 
     def user_params
-      accessible = [ :name, :email ] # extend with your own params
+      accessible = [ :name, :email, :bio, :company, :title ] # extend with your own params
       accessible << [ :password, :password_confirmation ] unless params[:user][:password].blank?
       params.require(:user).permit(accessible)
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,30 @@
+class UsersController < ApplicationController
+  before_action :set_user
+
+  # NOTE: This is for oauth users without email addresses.  This means twitter
+  # and sometimes github and facebook for sure.
+
+  # GET/PATCH /users/:id/finish_signup
+  def finish_signup
+    if request.patch? && params[:user] #&& params[:user][:email]
+      if @user.update(user_params)
+        # @user.skip_reconfirmation!
+        sign_in(@user, :bypass => true)
+        redirect_to root_path, notice: 'Your profile was successfully updated.'
+      else
+        @show_errors = true
+      end
+    end
+  end
+
+  private
+    def set_user
+      @user = User.find(params[:id])
+    end
+
+    def user_params
+      accessible = [ :name, :email ] # extend with your own params
+      accessible << [ :password, :password_confirmation ] unless params[:user][:password].blank?
+      params.require(:user).permit(accessible)
+    end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -24,6 +24,7 @@ class Post < ActiveRecord::Base
 
   validates :body, presence: true, length: { maximum: 10_000 }
   validates :kind, presence: true
+  validates :user_id, presence: true
 
   after_create  :update_waiting_on_cache
   after_create  :assign_on_reply

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,6 +51,8 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable,
          :omniauthable, :omniauth_providers => Devise.omniauth_providers
 
+  TEMP_EMAIL_PREFIX = 'change@me'
+
   validates :name, presence: true, format: { with: /\A\D+\z/ }
   validates :email, presence: true
 
@@ -105,7 +107,7 @@ class User < ActiveRecord::Base
       where(provider: auth.provider, uid: auth.uid).first_or_create do |u|
         u.provider = auth.provider
         u.uid = auth.uid
-        u.email = auth.provider == 'twitter' ? "#{auth.info.nickname}@twitter.com" : auth.info.email
+        u.email = auth.info.email.present? ? auth.info.email : "#{TEMP_EMAIL_PREFIX}-#{auth.uid}-#{auth.provider}.com"
         u.name = auth.info.name
         u.thumbnail = auth.info.image
         u.password = Devise.friendly_token[0,20]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -107,7 +107,7 @@ class User < ActiveRecord::Base
       where(provider: auth.provider, uid: auth.uid).first_or_create do |u|
         u.provider = auth.provider
         u.uid = auth.uid
-        u.email = auth.info.email.present? ? auth.info.email : temp_email(auth)
+        u.email = auth.info.email.present? ? auth.info.email : u.temp_email(auth)
         u.name = auth.info.name
         u.thumbnail = auth.info.image
         u.password = Devise.friendly_token[0,20]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -107,12 +107,16 @@ class User < ActiveRecord::Base
       where(provider: auth.provider, uid: auth.uid).first_or_create do |u|
         u.provider = auth.provider
         u.uid = auth.uid
-        u.email = auth.info.email.present? ? auth.info.email : "#{TEMP_EMAIL_PREFIX}-#{auth.uid}-#{auth.provider}.com"
+        u.email = auth.info.email.present? ? auth.info.email : temp_email(auth)
         u.name = auth.info.name
         u.thumbnail = auth.info.image
         u.password = Devise.friendly_token[0,20]
       end
     end
+  end
+
+  def temp_email(auth)
+    "#{TEMP_EMAIL_PREFIX}-#{auth.uid}-#{auth.provider}.com"
   end
 
   def to_param

--- a/app/views/users/finish_signup.html.erb
+++ b/app/views/users/finish_signup.html.erb
@@ -42,12 +42,12 @@
     <%= bootstrap_form_for(@user, :as => 'user', :url => finish_signup_path(id: @user.id), :html => { role: 'form'}) do |f| %>
     <%= devise_error_messages! %>
     <span class="user-fields">
-      <%= f.email_field :email, autofocus: true %>
+      <%= f.email_field :email, value: '', autofocus: true %>
       <%= f.text_field :name %>
       <%= f.text_area :bio %>
       <%= f.text_field :company %>
       <%= f.text_field :title %>
-      <%= f.text_area :signature if current_user.is_admin? %>
+      <%= f.text_area :signature if @user.is_admin? %>
       <% if @user.provider.nil? %>
         <%= f.attachinary_file_field :avatar unless Cloudinary.config.cloud_name.nil? %>
       <% end %>

--- a/app/views/users/finish_signup.html.erb
+++ b/app/views/users/finish_signup.html.erb
@@ -1,0 +1,73 @@
+<!-- <div id="add-email" class="container">
+  <h1>Add Email</h1>
+  <%= form_for(@user, :as => 'user', :url => finish_signup_path(id: @user.id), :html => { role: 'form'}) do |f| %>
+    <% if @show_errors && @user.errors.any? %>
+      <div id="error_explanation">
+        <% @user.errors.full_messages.each do |msg| %>
+          <%= msg %><br>
+        <% end %>
+      </div>
+    <% end %>
+    <div class="form-group">
+      <%= f.label :email %>
+      <div class="controls">
+        <%= f.text_field :email, :autofocus => true, :value => '', class: 'form-control input-lg', placeholder: 'Example: email@me.com' %>
+        <p class="help-block">Please confirm your email address. No spam.</p>
+      </div>
+    </div>
+    <div class="actions">
+      <%= f.submit 'Continue', :class => 'btn btn-primary' %>
+    </div>
+  <% end %>
+</div>
+
+<div id="page-title" class="row">
+  <div class="col-md-8" id="page-title-left">
+    <span class="hidden-xs">
+      <%= render_breadcrumbs('') %>
+    </span>
+    <h1><%= t(:your_profile) %></h1>
+  </div>
+  <div class="col-md-4" id="page-title-right">
+  </div>
+</div> -->
+
+<div class="row content-row">
+
+  <div class="col-md-3 text-center">
+    <%= avatar_image(@user, size=150) %>
+  </div>
+
+  <div class="col-md-9">
+    <%= bootstrap_form_for(@user, :as => 'user', :url => finish_signup_path(id: @user.id), :html => { role: 'form'}) do |f| %>
+    <%= devise_error_messages! %>
+    <span class="user-fields">
+      <%= f.email_field :email, autofocus: true %>
+      <%= f.text_field :name %>
+      <%= f.text_area :bio %>
+      <%= f.text_field :company %>
+      <%= f.text_field :title %>
+      <%= f.text_area :signature if current_user.is_admin? %>
+      <% if @user.provider.nil? %>
+        <%= f.attachinary_file_field :avatar unless Cloudinary.config.cloud_name.nil? %>
+      <% end %>
+    </span>
+
+    <% if @user.provider.nil? %>
+    <%= f.password_field :current_password, autocomplete: "off" %>
+
+    <br/><br/>
+    <h4><%= t(:change_password) %></h4>
+    <br/>
+    <span class="password-fields">
+      <%= f.password_field :password, autocomplete: "off" %>
+      <%= f.password_field :password_confirmation, autocomplete: "off"  %>
+    </span>
+    <% end %>
+
+    <%= f.submit t("save_changes"), class: 'btn btn-warning' %>
+
+  <% end %>
+
+  </div>
+</div>

--- a/app/views/users/finish_signup.html.erb
+++ b/app/views/users/finish_signup.html.erb
@@ -1,37 +1,3 @@
-<!-- <div id="add-email" class="container">
-  <h1>Add Email</h1>
-  <%= form_for(@user, :as => 'user', :url => finish_signup_path(id: @user.id), :html => { role: 'form'}) do |f| %>
-    <% if @show_errors && @user.errors.any? %>
-      <div id="error_explanation">
-        <% @user.errors.full_messages.each do |msg| %>
-          <%= msg %><br>
-        <% end %>
-      </div>
-    <% end %>
-    <div class="form-group">
-      <%= f.label :email %>
-      <div class="controls">
-        <%= f.text_field :email, :autofocus => true, :value => '', class: 'form-control input-lg', placeholder: 'Example: email@me.com' %>
-        <p class="help-block">Please confirm your email address. No spam.</p>
-      </div>
-    </div>
-    <div class="actions">
-      <%= f.submit 'Continue', :class => 'btn btn-primary' %>
-    </div>
-  <% end %>
-</div>
-
-<div id="page-title" class="row">
-  <div class="col-md-8" id="page-title-left">
-    <span class="hidden-xs">
-      <%= render_breadcrumbs('') %>
-    </span>
-    <h1><%= t(:your_profile) %></h1>
-  </div>
-  <div class="col-md-4" id="page-title-right">
-  </div>
-</div> -->
-
 <div class="row content-row">
 
   <div class="col-md-3 text-center">
@@ -39,34 +5,17 @@
   </div>
 
   <div class="col-md-9">
-    <%= bootstrap_form_for(@user, :as => 'user', :url => finish_signup_path(id: @user.id), :html => { role: 'form'}) do |f| %>
+    <%= simple_form_for(@user, url: finish_signup_path, validate: true, :html => { role: 'form'}) do |f| %>
     <%= devise_error_messages! %>
     <span class="user-fields">
-      <%= f.email_field :email, value: '', autofocus: true %>
-      <%= f.text_field :name %>
-      <%= f.text_area :bio %>
-      <%= f.text_field :company %>
-      <%= f.text_field :title %>
-      <%= f.text_area :signature if @user.is_admin? %>
-      <% if @user.provider.nil? %>
-        <%= f.attachinary_file_field :avatar unless Cloudinary.config.cloud_name.nil? %>
-      <% end %>
+      <%= f.input :email, input_html: { value: '', autofocus: true } %>
+      <%= f.input :name %>
+      <%= f.input :bio %>
+      <%= f.input :company %>
+      <%= f.input :title %>
     </span>
-
-    <% if @user.provider.nil? %>
-    <%= f.password_field :current_password, autocomplete: "off" %>
-
-    <br/><br/>
-    <h4><%= t(:change_password) %></h4>
-    <br/>
-    <span class="password-fields">
-      <%= f.password_field :password, autocomplete: "off" %>
-      <%= f.password_field :password_confirmation, autocomplete: "off"  %>
-    </span>
-    <% end %>
-
-    <%= f.submit t("save_changes"), class: 'btn btn-warning' %>
-
+    <%= f.button :submit, t("save_changes"), class: 'btn btn-warning' %>
+    <%#= f.button :submit %>
   <% end %>
 
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     #      omniauth_callbacks: "callbacks"
     #    }
 
+    match 'users/finish_signup' => 'users#finish_signup', via: [:get, :patch], :as => :finish_signup
     devise_for :users, skip: :omniauth_callbacks, controllers: { registrations: 'registrations' }
 
     resources :knowledgebase, :as => 'categories', :controller => "categories", except: [:new, :edit, :create, :update] do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -22,7 +22,7 @@ class UsersControllerTest < ActionController::TestCase
     session['omniauth_uid'] = '123545'
 
     # Mock a new user coming from Twitter
-    u = User.create!(
+    User.create!(
       email: 'change@me-123545-twitter.com',
       name: 'test user',
       password: '12345678',

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+class UsersControllerTest < ActionController::TestCase
+
+  setup do
+    set_default_settings
+  end
+
+  test "a browsing user should not be able to load the finish_signup page" do
+    get :finish_signup, id: 3, locale: :en
+    assert_redirected_to new_user_session_path
+  end
+
+  test "a signed in user should not be able to load the finish_signup page for another user" do
+    sign_in users(:user)
+    get :finish_signup, id: 3, locale: :en
+    assert_redirected_to new_user_session_path
+  end
+
+  # Should be able to GET the finish_signup page
+  test 'an oauth user should be able to finish their signup' do
+    session['omniauth_uid'] = '123545'
+
+    # Mock a new user coming from Twitter
+    u = User.create!(
+      email: 'change@me-123545-twitter.com',
+      name: 'test user',
+      password: '12345678',
+      uid: '123545',
+      provider: 'twitter'
+    )
+
+    get :finish_signup, locale: :en
+    assert_response :success
+  end
+
+  # Should be abel to PUT to the finish_signup page
+  test 'an oauth user without an email should be able save their completed signup' do
+    session['omniauth_uid'] = '123545'
+
+    # Mock a new user coming from Twitter
+    u = User.create!(
+      email: 'change@me-123545-twitter.com',
+      name: 'test user',
+      password: '12345678',
+      uid: '123545',
+      provider: 'twitter'
+    )
+
+    patch :finish_signup, { user: { email: "new@email.com", name: "test user" }, locale: :en }
+
+    # Reload the user to pick up the changes
+    u.reload
+    # assert_response :success
+    assert_equal u.email, "new@email.com"
+  end
+
+
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -174,14 +174,12 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "temp_email should be used if Oauth does not include an email address in response" do
-    user_count = User.count
     oath = OmniAuth::AuthHash.new({
                                     :provider  => 'facebook',
                                     :uid       => '123545',
                                     :info      => {}
                                   })
     user = User.find_for_oauth(oath)
-
     assert_equal user.email, user.temp_email(oath)
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -173,4 +173,16 @@ class UserTest < ActiveSupport::TestCase
     assert_equal '123545', user.uid
   end
 
+  test "temp_email should be used if Oauth does not include an email address in response" do
+    user_count = User.count
+    oath = OmniAuth::AuthHash.new({
+                                    :provider  => 'facebook',
+                                    :uid       => '123545',
+                                    :info      => {}
+                                  })
+    user = User.find_for_oauth(oath)
+
+    assert_equal user.email, user.temp_email(oath)
+  end
+
 end


### PR DESCRIPTION
This adds a check to make sure the oAuth response includes an email address and prompts users to provide one if not.