### PR TITLE
Fix strange behaviour in last activities inside posts

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -116,7 +116,7 @@ ul.dropdown-menu {
 }
 
 #user-tickets ul li {
-	height: 25px;
+	margin-bottom: 7px;
 	color: #666;
 }
 

--- a/app/views/admin/topics/_post.html.erb
+++ b/app/views/admin/topics/_post.html.erb
@@ -4,7 +4,7 @@
 		<%= avatar_image(post.user, size=40) %>
 	</div>
 	<div class="media-body media-right">
-		<span class="hidden-sm hidden-md hidden-lg"><%= post.kind == "first" ? last_active_time(post.created_at) : "#{distance_of_time_in_words(post.created_at,post.topic.created_at)} later" %><br/></span>
+		<span class="hidden-sm hidden-md hidden-lg"><%= last_active_time(post.created_at) %><br/></span>
 		<span id="row-<%= post.id %>"  class="post-menu post-menu-<%= post.id %> btn-group">
 			<%= post_message(post,true) %>
 			<ul class="dropdown-menu dropdown-menu-left" role="menu">
@@ -15,7 +15,7 @@
 
 		<span class="last-active posted-at less-important pull-right">
 			<span class="hidden-xs">
-			<%= post.kind == "first" ? last_active_time(post.created_at) : "#{distance_of_time_in_words(post.created_at,post.topic.created_at)} later" %>
+			<%= last_active_time(post.created_at) %>
 			</span>
 		</span>
 

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -13,14 +13,14 @@
 		<%= avatar_image(post.user, size=40) %>
 	</div>
 	<div class="media-body media-right">
-		<span class="hidden-sm hidden-md hidden-lg"><%= post.kind == "first" ? last_active_time(post.created_at) : "#{distance_of_time_in_words(post.created_at,post.topic.created_at)} later" %><br/></span>
+		<span class="hidden-sm hidden-md hidden-lg"><%= last_active_time(post.created_at) %><br/></span>
 		<span id="row-<%= post.id %>"  class="post-menu post-menu-<%= post.id %> btn-group">
 			<%= post_message(post) %>
 		</span>
 
 		<span class="last-active posted-at less-important pull-right">
 			<span class="hidden-xs">
-			<%= post.kind == "first" ? last_active_time(post.created_at) : "#{distance_of_time_in_words(post.created_at,post.topic.created_at)} later" %>
+				<%= last_active_time(post.created_at) %>
 			</span>
 		</span>
 

--- a/app/views/topics/_qna.html.erb
+++ b/app/views/topics/_qna.html.erb
@@ -18,7 +18,7 @@
       <%= avatar_image(post.user, size=40) %>
   	</div>
   	<div class="media-body media-right">
-  		<span class="hidden-sm hidden-md hidden-lg"><%= post.kind == "first" ? last_active_time(post.created_at) : "#{distance_of_time_in_words(post.created_at,post.topic.created_at)} later" %><br/></span>
+  		<span class="hidden-sm hidden-md hidden-lg"><%= last_active_time(post.created_at) %><br/></span>
   		<span id="row-<%= post.id %>"  class="post-menu post-menu-<%= post.id %> btn-group">
         <%= post_message(post) %>
   		</span>


### PR DESCRIPTION
I don't know if anyone notice a strange behaviour inside the list posts. Everytime that anyone inside Helpy reply a message, the activity time calculated is the same of the 'first' post.
Check my screenshots to more explanation:

Here the older code:
![timeline1](https://cloud.githubusercontent.com/assets/5271543/15954131/c0e1c816-2ea9-11e6-96cd-61001cd2f581.png)

The fix:
![timeline2](https://cloud.githubusercontent.com/assets/5271543/15954132/c0e98b8c-2ea9-11e6-86df-14495a9473bc.png)

---
Seems strange to me this behaviour, and the fix, is so simple. But I don't know if this solution is inside the Helpy code metrics. :blush: 