### PR TITLE
Add .ruby-gemset .ruby-verions and .rvmrc to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ config/settings_bu.yml
 
 *.eml
 .DS_Store
+
+/.ruby-version
+/.ruby-gemset
+/.rvmrc


### PR DESCRIPTION
Hey!
Usually, these files to select ruby version and gemset are added to gitignore.
I added them to gitignore.

Next question is should we fix ruby version in Gemfile? 2.2.1 seems outdated. Should we remove it?