### PR TITLE
Fix ApiKey test suite and make the whole test suite pass again

### DIFF
--- a/app/controllers/api/v1/topics.rb
+++ b/app/controllers/api/v1/topics.rb
@@ -73,7 +73,7 @@ module API
             user_id: params[:user_id],
             private: true
           )
-          post = topic.posts.create!(
+          topic.posts.create!(
             body: params[:body],
             user_id: params[:user_id],
             kind: 'first'

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -12,7 +12,7 @@
 #
 
 class ApiKey < ActiveRecord::Base
-  before_create :generate_access_token
+  before_validation :generate_access_token, on: :create
 
   belongs_to :user
   validates :access_token, uniqueness: true

--- a/app/models/entity/doc.rb
+++ b/app/models/entity/doc.rb
@@ -16,5 +16,5 @@ module Entity
     expose :updated_at
     expose :topics_count
     expose :allow_comments
-   end
- end
+  end
+end

--- a/test/fixtures/api_keys.yml
+++ b/test/fixtures/api_keys.yml
@@ -14,13 +14,13 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  token: MyString
+  access_token:
   user_id: 1
   name: MyString
-  expired: false
+  date_expired:
 
 two:
-  token: MyString
+  access_token:
   user_id: 1
   name: MyString
-  expired: false
+  date_expired: 

--- a/test/models/api_key_test.rb
+++ b/test/models/api_key_test.rb
@@ -17,9 +17,27 @@ class ApiKeyTest < ActiveSupport::TestCase
 
   should belong_to(:user)
 
-  test "creating a new Api Key should generate an access token" do
+  test "creating a new api key should generate an access token" do
     api_key = ApiKey.create!(name: "MyApiKey")
     assert_not_nil api_key.access_token
   end
+
+  test "updating an existing api key should not modify its access token" do
+    api_key = ApiKey.create!(name: "MyApiKey")
+    access_token = api_key.access_token
+    api_key.name = "ChangedApiKeyName"
+    api_key.save!
+    assert_equal access_token, api_key.access_token
+  end
+
+  test "expired should be false" do
+    api_key = ApiKey.create!(name: "MyApiKey")
+    assert (api_key.expired? == false), "ApiKey#expired? should be false when date_expired is not present"
+  end
+
+  test "expired should be true" do
+    api_key = ApiKey.create!(name: "MyApiKey", date_expired: 1.month.ago)
+    assert (api_key.expired? == true), "ApiKey#expired? should be true when date_expired is present"
+  end  
 
 end

--- a/test/models/api_key_test.rb
+++ b/test/models/api_key_test.rb
@@ -14,7 +14,12 @@
 require 'test_helper'
 
 class ApiKeyTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+
+  should belong_to(:user)
+
+  test "creating a new Api Key should generate an access token" do
+    api_key = ApiKey.create!(name: "MyApiKey")
+    assert_not_nil api_key.access_token
+  end
+
 end


### PR DESCRIPTION
Resolved a few issues with the test suite which were causing it to fail in CI

* Updated fixture definitions to use the current DB schema
* Fixed issue with `before_create` hook not generating the `access_token` before validation occurred (switched to `before_validation :generate_access_token on: :create`
* Added 100% test coverage for ApiKey model
* Fix a couple of Rubocop linting errors (line indenting, unused assigned variable)

Perhaps should add validation to ensure ApiKey is always assigned to a user?