### PR TITLE
Remove puts in favour of Ruby.logger.info

### DIFF
--- a/lib/email_processor.rb
+++ b/lib/email_processor.rb
@@ -2,9 +2,9 @@ class EmailProcessor
 
   def initialize(email)
     @email = email
-    puts @email
+    Rails.logger.info @email
+    Rails.logger.info "Tracking GA: #{Settings.google_analytics_id}"
 
-    puts "Tracking GA: #{Settings.google_analytics_id}"
     @tracker = Staccato.tracker(Settings.google_analytics_id)
   end
 


### PR DESCRIPTION
Test runs get some `puts` statements thrown in from the `email_processor.rb` class.

This commit simply changes `puts` into `Rails.logger.info` instead to keep the test output clean while leaving the info visible during development.