### PR TITLE
[API] Re-enable Doorkeeper::Grape::Helpers...

### DIFF
--- a/app/controllers/api/v1/categories.rb
+++ b/app/controllers/api/v1/categories.rb
@@ -23,7 +23,6 @@ module API
           notes: "Lists all active categories defined for the knowledgebase"
         }
         get "", root: :categories do
-          # authenticate!
           categories = Category.active.all
           present categories, with: Entity::Category
         end

--- a/app/controllers/api/v1/categories.rb
+++ b/app/controllers/api/v1/categories.rb
@@ -36,7 +36,7 @@ module API
           requires :id, type: String, desc: "Category to list docs from"
         end
         get ":id", root: :categories do
-          category = Category.where(id: permitted_params[:id]).first
+          category = Category.active.find(permitted_params[:id])
           present category, with: Entity::Category, docs: true
         end
 
@@ -86,7 +86,7 @@ module API
           optional :active, type: Boolean, desc: "Whether or not the category is live on the site"
         end
         patch ":id", root: :categories do
-          category = Category.where(id: permitted_params[:id]).first
+          category = Category.find(permitted_params[:id])
           category.update!(
             name: permitted_params[:name],
             icon: permitted_params[:icon],

--- a/app/controllers/api/v1/defaults.rb
+++ b/app/controllers/api/v1/defaults.rb
@@ -20,8 +20,9 @@ module API
           end
 
           def authenticate!
+            
             if doorkeeper_token
-               doorkeeper_authorize!
+              doorkeeper_authorize!
             else
               error!('Unauthorized. Invalid or expired token.', 401) unless current_user #||
             end

--- a/app/controllers/api/v1/docs.rb
+++ b/app/controllers/api/v1/docs.rb
@@ -26,7 +26,7 @@ module API
           requires :id, type: String, desc: "ID of the doc to show"
         end
         get ":id", root: "doc" do
-          doc = Doc.where(id: permitted_params[:id]).first!
+          doc = Doc.active.find(permitted_params[:id])
           present doc, with: Entity::Doc
         end
 
@@ -70,10 +70,10 @@ module API
         }
         params do
           requires :id, type: Integer, desc: "The ID of the Doc being updated"
-          requires :title, type: String, desc: "The name of the category of articles"
-          requires :category_id, type: Integer, desc: "The category the doc belongs to"
-          requires :body, type: String, desc: "The body/text of the article"
-          requires :user_id, type: Integer, desc: "The author of the article"
+          optional :title, type: String, desc: "The name of the category of articles"
+          optional :category_id, type: Integer, desc: "The category the doc belongs to"
+          optional :body, type: String, desc: "The body/text of the article"
+          optional :user_id, type: Integer, desc: "The author of the article"
           optional :keywords, type: String, desc: "Keywords that will be used for internal search and SEO"
           optional :title_tag, type: String, desc: "An alternate title tag that will be used if provided"
           optional :meta_description, type: String, desc: "A short description for SEO and internal purposes"
@@ -82,7 +82,7 @@ module API
           optional :active, type: Boolean, desc: "Whether or not the doc is live on the site"
         end
         patch ":id", root: :docs do
-          doc = Doc.where(id: permitted_params[:id])
+          doc = Doc.find(permitted_params[:id])
           doc.update!(
             title: permitted_params[:title],
             category_id: permitted_params[:category_id],

--- a/app/controllers/api/v1/docs.rb
+++ b/app/controllers/api/v1/docs.rb
@@ -3,13 +3,15 @@ require 'doorkeeper/grape/helpers'
 module API
   module V1
     class Docs < Grape::API
-      # helpers Doorkeeper::Grape::Helpers
+      helpers Doorkeeper::Grape::Helpers
       #
       # before do
       #   doorkeeper_authorize!
       # end
+      
       before do
         authenticate!
+        restrict_to_role %w(admin agent)
       end
 
       include API::V1::Defaults

--- a/app/controllers/api/v1/forums.rb
+++ b/app/controllers/api/v1/forums.rb
@@ -3,7 +3,7 @@ require 'doorkeeper/grape/helpers'
 module API
   module V1
     class Forums < Grape::API
-      # helpers Doorkeeper::Grape::Helpers
+      helpers Doorkeeper::Grape::Helpers
       #
       # before do
       #   doorkeeper_authorize!

--- a/app/controllers/api/v1/posts.rb
+++ b/app/controllers/api/v1/posts.rb
@@ -3,7 +3,7 @@ require 'doorkeeper/grape/helpers'
 module API
   module V1
     class Posts < Grape::API
-      # helpers Doorkeeper::Grape::Helpers
+      helpers Doorkeeper::Grape::Helpers
       #
       # before do
       #   doorkeeper_authorize!

--- a/app/controllers/api/v1/topics.rb
+++ b/app/controllers/api/v1/topics.rb
@@ -3,7 +3,7 @@ require 'doorkeeper/grape/helpers'
 module API
   module V1
     class Topics < Grape::API
-      # helpers Doorkeeper::Grape::Helpers
+      helpers Doorkeeper::Grape::Helpers
       #
       # before do
       #   doorkeeper_authorize!

--- a/app/controllers/api/v1/users.rb
+++ b/app/controllers/api/v1/users.rb
@@ -3,7 +3,7 @@ require 'doorkeeper/grape/helpers'
 module API
   module V1
     class Users < Grape::API
-      # helpers Doorkeeper::Grape::Helpers
+      helpers Doorkeeper::Grape::Helpers
       #
       # before do
       #   doorkeeper_authorize!

--- a/test/controllers/api/v1/categories_test.rb
+++ b/test/controllers/api/v1/categories_test.rb
@@ -1,0 +1,123 @@
+# == Schema Information
+#
+# Table name: categories
+#
+#  id               :integer          not null, primary key
+#  name             :string
+#  icon             :string
+#  keywords         :string
+#  title_tag        :string
+#  meta_description :string
+#  rank             :integer
+#  front_page       :boolean          default(FALSE)
+#  active           :boolean          default(TRUE)
+#  permalink        :string
+#  section          :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+
+require 'test_helper'
+
+class API::V1::CategoriesTest < ActiveSupport::TestCase
+  include Rack::Test::Methods
+
+  def app
+    Rails.application
+  end
+  
+  setup do
+    set_default_settings
+    @user = users(:admin)
+    @api_key = ApiKey.create(name: "Test Categories Key", user: @user)
+    @default_params = { token: @api_key.access_token }
+  end
+
+  test "an unauthenticated user should receive an unauthorized message" do
+    get '/api/v1/categories.json'
+
+    # Check not authorized
+    assert_equal 401, last_response.status
+  end 
+
+  test "an API user should be able to return categories" do
+    get '/api/v1/categories.json', @default_params
+
+    # Check OK
+    assert last_response.ok?, "Response was #{last_response.status}, expected 200"
+
+    # Check returned value
+    objects = JSON.parse(last_response.body)
+    assert objects.length == Category.active.count, "Only #{objects.length} returned out of #{Category.active.count} categories"
+  end
+
+  test "an API user should be able to return a specific category" do
+    category = Category.first
+    get "/api/v1/categories/#{category.id}.json", @default_params
+
+    # Check OK
+    assert last_response.ok?, "Response was #{last_response.status}, expected 200"
+
+    # Check returned value
+    object = JSON.parse(last_response.body)  
+    assert object['id'] == category.id
+    assert object['name'] == category.name
+  end
+
+  test "an API user should not be able to return inactive categories" do
+    category = Category.find_by(active: false)
+    get "/api/v1/categories/#{category.id}.json", @default_params
+
+    # Check not found
+    assert_equal 404, last_response.status
+  end
+
+  test "an API user should be able to create a category" do
+    params = {
+      name: Faker::Company.catch_phrase,
+      icon: "clock",
+      keywords: Faker::Lorem.words(4).join(','),
+      title_tag: Faker::Company.catch_phrase,
+      meta_description: Faker::Lorem.paragraph,
+      rank: Faker::Number.between(1, 10),
+      front_page: true,
+      active: true
+    }
+
+    post '/api/v1/categories.json', @default_params.merge(params)
+
+    object = JSON.parse(last_response.body)
+
+    assert_equal object['name'], params[:name]
+  end
+
+  test "an API user should not be able to create an invalid category" do
+    params = {
+      name: nil,
+      icon: "clock",
+      keywords: Faker::Lorem.words(4).join(','),
+      title_tag: Faker::Company.catch_phrase,
+      meta_description: Faker::Lorem.paragraph,
+      rank: Faker::Number.between(1, 10),
+      front_page: true,
+      active: true
+    }
+
+    post '/api/v1/categories.json', @default_params.merge(params)
+
+    assert_equal 422, last_response.status
+  end
+
+  test "an API user should be able to update a category" do
+    category = Category.first
+    params = {
+      name: Faker::Company.catch_phrase,
+    }
+
+    patch "/api/v1/categories/#{category.id}.json", @default_params.merge(params)
+
+    object = JSON.parse(last_response.body)
+
+    assert_equal object['name'], params[:name]
+  end
+end

--- a/test/controllers/api/v1/categories_test.rb
+++ b/test/controllers/api/v1/categories_test.rb
@@ -88,7 +88,7 @@ class API::V1::CategoriesTest < ActiveSupport::TestCase
 
     object = JSON.parse(last_response.body)
 
-    assert_equal object['name'], params[:name]
+    assert_equal params[:name], object['name']
   end
 
   test "an API user should not be able to create an invalid category" do
@@ -111,13 +111,13 @@ class API::V1::CategoriesTest < ActiveSupport::TestCase
   test "an API user should be able to update a category" do
     category = Category.first
     params = {
-      name: Faker::Company.catch_phrase,
+      name: Faker::Company.catch_phrase
     }
 
     patch "/api/v1/categories/#{category.id}.json", @default_params.merge(params)
 
     object = JSON.parse(last_response.body)
 
-    assert_equal object['name'], params[:name]
+    assert_equal params[:name], object['name']
   end
 end

--- a/test/controllers/api/v1/docs_test.rb
+++ b/test/controllers/api/v1/docs_test.rb
@@ -1,0 +1,115 @@
+# == Schema Information
+#
+# Table name: docs
+#
+#  id               :integer          not null, primary key
+#  title            :string
+#  body             :text
+#  keywords         :string
+#  title_tag        :string
+#  meta_description :string
+#  category_id      :integer
+#  user_id          :integer
+#  active           :boolean          default(TRUE)
+#  rank             :integer
+#  permalink        :string
+#  version          :integer
+#  front_page       :boolean          default(FALSE)
+#  cheatsheet       :boolean          default(FALSE)
+#  points           :integer          default(0)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  topics_count     :integer          default(0)
+#  allow_comments   :boolean          default(TRUE)
+#
+
+
+require 'test_helper'
+
+class API::V1::DocsTest < ActiveSupport::TestCase
+  include Rack::Test::Methods
+
+  def app
+    Rails.application
+  end
+  
+  setup do
+    set_default_settings
+    @user = users(:admin)
+    @api_key = ApiKey.create(name: "Test Docs Key", user: @user)
+    @default_params = { token: @api_key.access_token }
+  end
+
+  test "an unauthenticated user should receive an unauthorized message" do
+    doc = Doc.first
+    get "/api/v1/docs/#{doc.id}.json"
+
+    # Check not authorized
+    assert_equal 401, last_response.status
+  end 
+
+  test "an API user should be able to return a specific doc" do
+    doc = Doc.first
+    get "/api/v1/docs/#{doc.id}.json", @default_params
+
+    # Check OK
+    assert last_response.ok?, "Response was #{last_response.status}, expected 200"
+
+    # Check returned value
+    object = JSON.parse(last_response.body)  
+    assert object['id'] == doc.id
+    assert object['title'] == doc.title
+  end
+
+  test "an API user should not be able to return inactive docs" do
+    doc = Doc.find_by(active: false)
+    get "/api/v1/docs/#{doc.id}.json", @default_params
+
+    # Check not found
+    assert_equal 404, last_response.status
+  end
+
+  test "an API user should be able to create a doc" do
+    params = {
+      title: Faker::Company.catch_phrase,
+      body: Faker::Lorem.paragraph,
+      category_id: Category.first.id,
+      user_id: User.first.id
+    }
+
+    post '/api/v1/docs.json', @default_params.merge(params)
+
+    object = JSON.parse(last_response.body)
+
+    assert_equal params[:title], object['title']
+  end
+
+  test "an API user should not be able to create an invalid doc" do
+    params = {
+      title: nil,
+      body: Faker::Lorem.paragraph,
+      category_id: Category.first.id,
+      user_id: User.first.id
+    }
+
+    post '/api/v1/docs.json', @default_params.merge(params)
+
+    assert_equal 422, last_response.status
+  end
+
+  test "an API user should be able to update a doc" do
+    doc = Doc.first
+    params = {
+      title: Faker::Company.catch_phrase,
+      category_id: Category.first.id,
+      front_page: false
+    }
+
+    patch "/api/v1/docs/#{doc.id}.json", @default_params.merge(params)
+
+    object = JSON.parse(last_response.body)
+
+    assert_equal params[:title], object['title']
+    assert_equal params[:front_page], object['front_page']
+  end
+end

--- a/test/fixtures/api_keys.yml
+++ b/test/fixtures/api_keys.yml
@@ -14,13 +14,13 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  access_token:
+  access_token: b01f26ba42fb17af8889ca5dfc5c9147
   user_id: 1
   name: MyString
   date_expired:
 
 two:
-  access_token:
+  access_token: 884ca3cede869c3979129f8c0d02f772
   user_id: 1
   name: MyString
   date_expired: 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
 # Simplecov to give a report of the test coverage on local development environment
 require 'simplecov'
-SimpleCov.start
+SimpleCov.start 'rails'
 
 #require 'codeclimate-test-reporter'
 #CodeClimate::TestReporter.start


### PR DESCRIPTION
...so authentication works correctly with the authorization code in the base class

I'm guessing you wanted to add some more work around the doorkeeper/OAuth functionality. For my purposes the ApiKey token is just fine...

This gets the API working again without too much hassle. You can pass in a param of `token=` or `X-Token` as a header


EDIT: 
* Added test coverage for Categories API controller
* Added test coverage for Docs API controller
* Changed `Simplecov.start` to `Simplecov.start 'rails'`