### PR TITLE
[API] Fix docs sorting and add limit option

### DIFF
--- a/app/controllers/api/v1/categories.rb
+++ b/app/controllers/api/v1/categories.rb
@@ -22,10 +22,13 @@ module API
           entity: Entity::Category,
           notes: "Lists all active categories defined for the knowledgebase"
         }
+        params do
+          optional :docs, type: Boolean, desc: "Whether to include the documents in the response"
+          optional :docs_limit, type: Integer, desc: "How many docs to return with the category"
+        end
         get "", root: :categories do
-          # authenticate!
-          categories = Category.active.all
-          present categories, with: Entity::Category
+          categories = Category.includes(:translations).active.ranked.all
+          present categories, with: Entity::Category, docs: permitted_params[:docs], docs_limit: permitted_params[:docs_limit]
         end
 
         # SHOW CATEGORY

--- a/app/models/entity/category.rb
+++ b/app/models/entity/category.rb
@@ -11,6 +11,8 @@ module Entity
     expose :active#, documentation: {type: 'String', desc: 'Whether or not the category is live on the site'}
     expose :created_at
     expose :updated_at
-    expose :docs, using: Entity::Doc, if: { docs: true }
+    expose :docs, using: Entity::Doc, if: { docs: true } do |category, options|
+      category.docs.includes(:translations).ordered.limit(options[:docs_limit])        
+    end
   end
 end


### PR DESCRIPTION
Ensure categories and docs are returned sorted by rank.
Eager load translations to save on DB queries
Add `docs_limit` option to limit the number of docs returned in the nested entities

