### PR TITLE
[API] Add category option to docs entity

### DIFF
--- a/app/controllers/api/v1/categories.rb
+++ b/app/controllers/api/v1/categories.rb
@@ -8,7 +8,6 @@ module API
       # before do
       #   doorkeeper_authorize!
       # end
-
       before do
         authenticate!
         restrict_to_role %w(admin agent)

--- a/app/controllers/api/v1/docs.rb
+++ b/app/controllers/api/v1/docs.rb
@@ -22,10 +22,11 @@ module API
         }
         params do
           requires :id, type: String, desc: "ID of the doc to show"
+          optional :category, type: Boolean, desc: "Whether to return the category object in full"
         end
         get ":id", root: "doc" do
           doc = Doc.where(id: permitted_params[:id]).first!
-          present doc, with: Entity::Doc
+          present doc, with: Entity::Doc, category: permitted_params[:category]
         end
 
         # CREATE NEW DOC

--- a/app/models/entity/doc.rb
+++ b/app/models/entity/doc.rb
@@ -16,5 +16,6 @@ module Entity
     expose :updated_at
     expose :topics_count
     expose :allow_comments
+    expose :category, using: Entity::Category, if: { category: true }
   end
 end


### PR DESCRIPTION
Allow category object to be returned as part of the doc object, if `category=true` is passed in as a param