### PR TITLE
[API] Add docs search functionality

### DIFF
--- a/app/controllers/api/v1/base.rb
+++ b/app/controllers/api/v1/base.rb
@@ -12,6 +12,7 @@ module API
       mount API::V1::Topics
       mount API::V1::Posts
       mount API::V1::Users
+      mount API::V1::Search
       add_swagger_documentation
     end
   end

--- a/app/controllers/api/v1/docs.rb
+++ b/app/controllers/api/v1/docs.rb
@@ -43,10 +43,11 @@ module API
         }
         params do
           requires :id, type: String, desc: "ID of the doc to show"
+          optional :category, type: Boolean, desc: "Whether to return the category object in full"
         end
         get ":id", root: "doc" do
           doc = Doc.active.find(permitted_params[:id])
-          present doc, with: Entity::Doc
+          present doc, with: Entity::Doc, category: permitted_params[:category]
         end
 
         # CREATE NEW DOC

--- a/app/controllers/api/v1/docs.rb
+++ b/app/controllers/api/v1/docs.rb
@@ -14,6 +14,25 @@ module API
 
       include API::V1::Defaults
       resource :docs do
+        ## SEARCH EXISTING DOCS
+        desc "Search docs", {
+          entity: Entity::Doc,
+          notes: "Search for docs by query"
+        }
+        params do
+          requires :q, type: String, desc: "The query term to search for"
+          optional :page, type: Integer, desc: "The current page"
+          optional :per_page, type: Integer, desc: "The number of results to return per page"
+        end
+        get "search", root: :doc do
+          results = PgSearch.multisearch(permitted_params[:q])
+                            .includes(:searchable)
+                            .where(searchable_type: "Doc")
+                            .page(permitted_params[:page])
+                            .per(permitted_params[:per_page])
+          docs = results.map(&:searchable)
+          present docs, with: Entity::Doc, category: true
+        end
 
         # SHOW A SINGLE DOC
         desc "Shows a single doc", {
@@ -95,6 +114,8 @@ module API
           )
           present doc, with: Entity::Doc
         end
+
+        
 
       end
     end

--- a/app/controllers/api/v1/docs.rb
+++ b/app/controllers/api/v1/docs.rb
@@ -16,25 +16,6 @@ module API
 
       include API::V1::Defaults
       resource :docs do
-        ## SEARCH EXISTING DOCS
-        desc "Search docs", {
-          entity: Entity::Doc,
-          notes: "Search for docs by query"
-        }
-        params do
-          requires :q, type: String, desc: "The query term to search for"
-          optional :page, type: Integer, desc: "The current page"
-          optional :per_page, type: Integer, desc: "The number of results to return per page"
-        end
-        get "search", root: :doc do
-          results = PgSearch.multisearch(permitted_params[:q])
-                            .includes(:searchable)
-                            .where(searchable_type: "Doc")
-                            .page(permitted_params[:page])
-                            .per(permitted_params[:per_page])
-          docs = results.map(&:searchable)
-          present docs, with: Entity::Doc, category: true
-        end
 
         # SHOW A SINGLE DOC
         desc "Shows a single doc", {
@@ -117,8 +98,6 @@ module API
           )
           present doc, with: Entity::Doc
         end
-
-        
 
       end
     end

--- a/app/controllers/api/v1/search.rb
+++ b/app/controllers/api/v1/search.rb
@@ -23,7 +23,7 @@ module API
         params do
           requires :q, type: String, desc: "The query term to search for"
           optional :type, type: String, desc: "The type of entity to search for"
-          optional :page, type: Integer, desc: "The current page"
+          optional :page, type: Integer, desc: "The current page", default: 1
           optional :per_page, type: Integer, desc: "The number of results to return per page", default: 25
         end
         get "", root: :search do

--- a/app/controllers/api/v1/search.rb
+++ b/app/controllers/api/v1/search.rb
@@ -1,0 +1,67 @@
+require 'doorkeeper/grape/helpers'
+
+module API
+  module V1
+    class Search < Grape::API
+      helpers Doorkeeper::Grape::Helpers
+      #
+      # before do
+      #   doorkeeper_authorize!
+      # end
+      
+      before do
+        authenticate!
+        restrict_to_role %w(admin agent)
+      end
+
+      include API::V1::Defaults
+      resource :search do
+        ## SEARCH PUBLIC KNOWLEDGEBASE
+        desc "Search the knowledgebase", {
+          notes: "Search for docs, posts, and topics by query"
+        }
+        params do
+          requires :q, type: String, desc: "The query term to search for"
+          optional :type, type: String, desc: "The type of entity to search for"
+          optional :page, type: Integer, desc: "The current page"
+          optional :per_page, type: Integer, desc: "The number of results to return per page", default: 25
+        end
+        get "", root: :search do
+
+          # Build initial results of the search
+          results = PgSearch.multisearch(permitted_params[:q])
+                            .page(permitted_params[:page])
+                            .per(permitted_params[:per_page])
+
+          # Scope results to supplied type
+          if permitted_params[:type].present?
+            # Convert pluralized into singular for the searcher
+            type = permitted_params[:type].singularize.camelize
+            results = results.where(searchable_type: type)
+                             .includes(:searchable)            
+          end
+
+          # Grab total pagesnow in case we have to map the results array
+          total_pages = results.total_pages 
+
+
+          # Check what kind of entity we are searching for and modify the Entity output accordingly
+          entity = case type
+                   when nil
+                     Entity::Search
+                   when 'Doc', 'Topic', 'User'
+                     results = results.map(&:searchable)
+                     "Entity::#{type}".constantize
+                   end
+
+          present pages: { 
+            page: permitted_params[:page], 
+            per_page: permitted_params[:per_page],
+            total_pages: total_pages
+          }
+          present :results, results, with: entity
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/search.rb
+++ b/app/controllers/api/v1/search.rb
@@ -59,7 +59,7 @@ module API
             per_page: permitted_params[:per_page],
             total_pages: total_pages
           }
-          present :results, results, with: entity
+          present :results, results, with: entity, category: true
         end
       end
     end

--- a/app/models/entity/search.rb
+++ b/app/models/entity/search.rb
@@ -1,0 +1,10 @@
+module Entity
+  class Search < Base
+    expose :id
+    expose :content
+    expose :searchable_id
+    expose :searchable_type
+    expose :created_at
+    expose :updated_at
+  end
+end

--- a/test/controllers/api/v1/search_test.rb
+++ b/test/controllers/api/v1/search_test.rb
@@ -1,0 +1,80 @@
+require 'test_helper'
+
+class API::V1::SearchTest < ActiveSupport::TestCase
+  include Rack::Test::Methods
+
+  def app
+    Rails.application
+  end
+  
+  setup do
+    set_default_settings
+    @user = users(:admin)
+    @api_key = ApiKey.create(name: "Test Search Key", user: @user)
+    @default_params = { token: @api_key.access_token }
+
+
+    @docs = []
+    @docs << docs(:one)
+    @docs << docs(:two)
+    @docs << docs(:three)
+    @docs << docs(:six)
+
+    # Need to rebuild the results to ensure they are ready
+    PgSearch::Multisearch.rebuild(Doc)
+  end
+
+  test "an unauthenticated user should receive an unauthorized message" do
+    get "/api/v1/search.json"
+
+    # Check not authorized
+    assert_equal 401, last_response.status
+  end 
+
+  test "it should require a query parameter" do
+    get "/api/v1/search.json", @default_params
+
+    # Check 400 response
+    assert_equal 400, last_response.status
+  end  
+
+  test "an API user should be able to return some results" do
+    get "/api/v1/search.json", @default_params.merge(q: 'Article')
+
+    # Check OK
+    assert last_response.ok?, "Response was #{last_response.status}, expected 200"
+
+    # Check returned value
+    objects = JSON.parse(last_response.body)
+    assert_equal 4, objects['results'].count
+  end
+
+  test "an API user should be able to return some results filtered by type" do
+    get "/api/v1/search.json", @default_params.merge(q: 'Article', type: 'docs')
+
+    # Check OK
+    assert last_response.ok?, "Response was #{last_response.status}, expected 200"
+
+    # Check returned value
+    objects = JSON.parse(last_response.body)
+    #raise objects.inspect
+    assert_equal 4, objects['results'].count
+  end
+
+
+  test "results filtered by type should return the proper Entity" do
+    get "/api/v1/search.json", @default_params.merge(q: @docs.first.title, type: 'docs')
+
+    # Check OK
+    assert last_response.ok?, "Response was #{last_response.status}, expected 200"
+
+    # Check returned value
+    objects = JSON.parse(last_response.body)
+    results = objects['results']
+    assert_equal 1, results.count
+
+    # Check returned Entity
+    assert_equal @docs.first.title, results.first['title']
+  end  
+
+end


### PR DESCRIPTION
Add functionality to support searching using the existing PG multisearch feature, but limited to just Docs.
This was a requirement in my case, might not be for everyone...

Pass in `/api/v1/docs/search?q=mysearch`