### PR TITLE
Replace 'quiet_assets' gem with config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -131,9 +131,8 @@ end
 
 group :development do
   gem "better_errors"
-  gem "quiet_assets"
   gem 'mailcatcher'
-  
+
   # Check Eager Loading / N+1 query problems
   gem 'bullet'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,8 +311,6 @@ GEM
       arel
     pkg-config (1.1.7)
     powerpack (0.1.1)
-    quiet_assets (1.1.0)
-      railties (>= 3.1, < 5.0)
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
@@ -570,7 +568,6 @@ DEPENDENCIES
   permalink_fu
   pg
   pg_search
-  quiet_assets
   rails (= 4.2.7)
   rails-i18n (~> 4.0.0)
   rails-settings-cached (~> 0.5)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,6 +39,9 @@ Rails.application.configure do
   # yet still be able to expire them through the digest params.
   config.assets.digest = true
 
+  # Mute asset pipeline log messages
+  config.assets.quiet = true
+
   # Adds additional error checking when serving assets at runtime.
   # Checks for improperly declared sprockets dependencies.
   # Raises helpful error messages.


### PR DESCRIPTION
Depends on #230.

This PR simply removes deprecated [quiet_assets gem](https://github.com/evrone/quiet_assets) replacing it with a config option as documented in their [readme](https://github.com/evrone/quiet_assets#deprecation).