### PR TITLE
Update 'devise' gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,12 +124,11 @@ GEM
     daemons (1.2.3)
     debug_inspector (0.0.2)
     deep_merge (1.0.1)
-    devise (3.5.6)
+    devise (4.2.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 3.2.6, < 5)
+      railties (>= 4.1.0, < 5.1)
       responders
-      thread_safe (~> 0.1)
       warden (~> 1.2.3)
     devise-bootstrap-views (0.0.8)
     devise-i18n (1.0.1)
@@ -243,7 +242,7 @@ GEM
       maildir (>= 0.5.0)
     mime-types (2.99.1)
     mini_portile2 (2.1.0)
-    minitest (5.8.4)
+    minitest (5.9.0)
     minitest-reporters (1.1.8)
       ansi
       builder
@@ -358,7 +357,7 @@ GEM
       json
     regexp_parser (0.3.3)
     request_store (1.3.1)
-    responders (2.1.2)
+    responders (2.2.0)
       railties (>= 4.2.0, < 5.1)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)


### PR DESCRIPTION
There don't seem to be any deprecations or removals affecting our codebase.

See [changelog for 4.x](https://github.com/plataformatec/devise/blob/master/CHANGELOG.md).