### PR TITLE
Do not allow send email on internal note

### DIFF
--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -2,14 +2,7 @@ class Admin::PostsController < Admin::BaseController
 
   before_action :verify_agent
   after_action :send_message, :only => 'create'
-  # respond_to :html, only: ['destroy']
   respond_to :js
-
-  # def new
-  #   @topic = Topic.find(params[:topic_id], :include => :forum)
-  #   @post = Post.new
-  #   @forums = Forum.all
-  # end
 
   def edit
     @post = Post.where(id: params[:id]).first
@@ -56,17 +49,11 @@ class Admin::PostsController < Admin::BaseController
     render action: 'update' if @post.save
   end
 
-  # def destroy
-  #   @post = Post.find(params[:id])
-  #   @post.destroy
-  #   respond_to do |format|
-  #      format.html { redirect_to topic_posts_path(@post.topic) }
-  #   end
-  # end
-
   protected
 
   def send_message
+   return if @post.kind == 'note'
+
     #Should only send when admin posts, not when user replies
     if @post.kind == 'first'
       email_locale = I18n.locale

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -29,7 +29,6 @@ class Post < ActiveRecord::Base
   after_create  :update_waiting_on_cache
   after_create  :assign_on_reply
   after_save  :update_topic_cache
-  #after_save :send_message
 
   scope :all_by_topic, -> (topic) { where("topic_id = ?", topic).order('updated_at ASC').include(user) }
   scope :active, -> { where(active: true) }

--- a/test/controllers/admin/posts_controller_test.rb
+++ b/test/controllers/admin/posts_controller_test.rb
@@ -48,6 +48,18 @@ class Admin::PostsControllerTest < ActionController::TestCase
       assert :success
     end
 
+    # Should not send email out for internal notes
+    test "an #{admin} should be able to post an internal note, and the system should NOT send an email" do
+      sign_in users(admin.to_sym)
+
+      assert_difference "ActionMailer::Base.deliveries.size", 0 do
+        assert_difference "Post.count", 1 do
+          xhr :post, :create, topic_id: 1, locale: :en, post: { user_id: User.find(2).id, body: "new internal note", kind: "note" }
+        end
+      end
+      assert :success
+    end
+
     test "an #{admin} should be able to reply to a public topic, and the system should NOT send an email" do
       sign_in users(admin.to_sym)
 
@@ -76,10 +88,10 @@ class Admin::PostsControllerTest < ActionController::TestCase
 
     test "an #{admin} should be able to post a reply with resolve flag which should change topic status to closed" do
       sign_in users(admin.to_sym)
-      old_post_count = Post.count     
+      old_post_count = Post.count
       xhr :post, :create, topic_id: 2, locale: :en, post: { user_id: User.find(1).id, body: "new reply", kind: "reply", resolved: "1" }
       assert old_post_count < Post.count
-      assert old_post_count == (Post.count - 2) # two post created one for "new reply" one for "closing" internel note 
+      assert old_post_count == (Post.count - 2) # two post created one for "new reply" one for "closing" internel note
       assert Topic.find(2).current_status == "closed"
     end
   end


### PR DESCRIPTION
It appeared internal notes were being emailed.  Fixed this and added a test to ensure it stays that way.