### PR TITLE
Revert "Update 'devise' gem"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,11 +124,12 @@ GEM
     daemons (1.2.3)
     debug_inspector (0.0.2)
     deep_merge (1.0.1)
-    devise (4.2.0)
+    devise (3.5.6)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0, < 5.1)
+      railties (>= 3.2.6, < 5)
       responders
+      thread_safe (~> 0.1)
       warden (~> 1.2.3)
     devise-bootstrap-views (0.0.8)
     devise-i18n (1.0.1)
@@ -366,7 +367,7 @@ GEM
       json
     regexp_parser (0.3.3)
     request_store (1.3.1)
-    responders (2.2.0)
+    responders (2.1.2)
       railties (>= 4.2.0, < 5.1)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)


### PR DESCRIPTION
Reverts helpyio/helpy#236 

I noticed the following exception:

```
undefined method `user_omniauth_authorize_path' for #<#<Class:0x007febb7b0fe50>:0x007febb7af73a0>

def login_with(with, redirect_to = "/#{I18n.locale}")
    provider = (with == "google_oauth2") ? "google" : with
    link_to(user_omniauth_authorize_path(with.to_sym, origin: redirect_to), class: ["btn","btn-block","btn-social","oauth","btn-#{provider}"], style: "color:white;", data: {provider: "#{provider}"}) do
      content_tag(:span, '', {class: ["fa", "fa-#{provider}"]}).html_safe + I18n.t("devise.shared.links.sign_in_with_provider", provider: provider.titleize)
    end
  end
```