### PR TITLE
GA direct cookie

### DIFF
--- a/app/assets/javascripts/event-tracking.js
+++ b/app/assets/javascripts/event-tracking.js
@@ -4,35 +4,13 @@
 var Helpy = Helpy || {};
 Helpy.track = function(){
 
-  // Get the GA Universal Analytics ClientID.  This is used for server side tracking
+  // Put the Google Analytics clientID into the Helpy data layer
   ga(function(tracker) {
     Helpy.clientId = tracker.get('clientId');
-    $("#client_id").val(Helpy.clientId);
-    console.log("trackerID: " + Helpy.clientId);
 
-    // Send ajax call with clientID if it is not set
-    var sessionSet = Cookies.get('sessInit');
-    if (sessionSet !== '1') {
-      $.ajax({
-        method: "GET",
-        url: "/set_client_id?client_id=" + Helpy.clientId,
-        data: { client_id: Helpy.clientId  }
-      })
-      .done(function( msg ) {
-        console.log("Session set to trackerID: " + Helpy.clientId);
-
-        // set a cookie to prevent making this call every time
-        Cookies.set('sessInit', '1');
-      });
+    // Do some more stuff here if you want...
     }
   });
-
-
-  // send search event to google
-//  $('#search-form').unbind().on('submit', function(){
-//    console.log($('#search-field').val())
-//    ga('send', 'event', 'Search','Search', $('#search-field').val())
-//  });
 
   // Search Events
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,12 +40,16 @@ class ApplicationController < ActionController::Base
 
   def tracker(ga_category, ga_action, ga_label, ga_value=nil)
     if AppSettings['settings.google_analytics_id'].present?
+      ga_cookie = cookies['_ga'].split('.')
+      ga_client_id = ga_cookie[2] + '.' + ga_cookie[3]
+      logger.info("Enqueing job for #{ga_client_id}")
+
       TrackerJob.perform_later(
         ga_category,
         ga_action,
         ga_label,
         ga_value,
-        session['client_id'] || params[:client_id],
+        ga_client_id,
         AppSettings['settings.google_analytics_id']
       )
     end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -12,9 +12,4 @@ class HomeController < ApplicationController
     @categories = Category.active.ordered.featured.all.with_translations(I18n.locale)
   end
 
-  def set_client_id
-    session[:client_id] = params[:client_id]
-    render nothing: true
-  end
-
 end

--- a/app/themes/helpy/assets/javascripts/helpy/event-tracking.js
+++ b/app/themes/helpy/assets/javascripts/helpy/event-tracking.js
@@ -4,35 +4,13 @@
 var Helpy = Helpy || {};
 Helpy.track = function(){
 
-  // Get the GA Universal Analytics ClientID.  This is used for server side tracking
+  // Put the Google Analytics clientID into the Helpy data layer
   ga(function(tracker) {
     Helpy.clientId = tracker.get('clientId');
-    $("#client_id").val(Helpy.clientId);
-    console.log("trackerID: " + Helpy.clientId);
 
-    // Send ajax call with clientID if it is not set
-    var sessionSet = Cookies.get('sessInit');
-    if (sessionSet !== '1') {
-      $.ajax({
-        method: "GET",
-        url: "/set_client_id?client_id=" + Helpy.clientId,
-        data: { client_id: Helpy.clientId  }
-      })
-      .done(function( msg ) {
-        console.log("Session set to trackerID: " + Helpy.clientId);
-
-        // set a cookie to prevent making this call every time
-        Cookies.set('sessInit', '1');
-      });
+    // Do some more stuff here if you want...
     }
   });
-
-
-  // send search event to google
-//  $('#search-form').unbind().on('submit', function(){
-//    console.log($('#search-field').val())
-//    ga('send', 'event', 'Search','Search', $('#search-field').val())
-//  });
 
   // Search Events
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,7 +44,6 @@ Rails.application.routes.draw do
   end
 
   get '/switch_locale' => 'home#switch_locale', as: :switch_locale
-  get '/set_client_id' => 'home#set_client_id', as: :set_client_id
 
   # Admin Routes
 


### PR DESCRIPTION
Access the GA cookie directly from server instead of using `set_client_id` pass-thru.  This resolves a problem where the clientID was not passed into jobs correctly and is a lot more efficient, although brittle if Google changes their cookie.