### PR TITLE
Avoid running all migrations on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ rvm:
 services:
   - postgresql
 
-# Setup Test Database
 before_script:
+  # Setup Test Database
   - psql -c 'create database helpy_test;' -U postgres
 
 script:
-  # Migrate database
-  - bin/rake db:migrate RAILS_ENV=test
+  # Load database schema
+  - bundle exec rake db:schema:load
   # Test suite
   - bundle exec rake
   # Brakeman security scanner


### PR DESCRIPTION
I noticed that the TravisCI build is running the full set of migrations. This is not a good practice (as quoted from the generated `db/schema.rb` file:

> If you need to create the application database on another system, you should be using db:schema:load, not running all the migrations from scratch.

Given that the database is re-created for every build anyway, we're not actually testing by "migrating" previous changes; we should just load the schema (using `db:schema:load`).

I appreciate that some Helpy migrations (eg. [AddDocIdToTopic](https://github.com/helpyio/helpy/blob/master/db/migrate/20160310044144_add_doc_id_to_topic.rb)) actually populate data (and I understand why that was needed for existing installations), but I'm concerned that any new users setting up Helpy will setup their database via `db:schema:load` (best practice) rather than through running all migrations (which is error-prone). It's important that we're running our tests against the same environment as new users / setups are likely to have.