### PR TITLE
Update Ruby version to latest (2.2.5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.2.1
+  - 2.2.5
 
 services:
   - postgresql

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby "2.2.5"
+
 gem 'rails', '4.2.7'
 
 # Use postgresql as the database for Active Record
@@ -158,5 +160,3 @@ group :production do
   gem 'rails_12factor'
   gem 'unicorn'
 end
-
-ruby "2.2.1"


### PR DESCRIPTION
Rails 5 depends on Ruby >= 2.2.2. I'm updating here to the latest available in the 2.2.x series as suggested in #224.

We should consider how existing users will migrate - hopefully there'll be no impact if they re-deploy to Heroku, but are there other providers or situations that we should document in the release notes, perhaps?

Also, we could just make the leap to 2.3.x directly - I'm not aware of any breaking changes, but we'd have to change the "minimum requirements" in the README and there aren't any important improvements in 2.3.x that we can't live without, so probably no need yet.
