### PR TITLE
JSHint: Resolve violations and run on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ services:
 before_script:
   # Setup Test Database
   - psql -c 'create database helpy_test;' -U postgres
+  # Prepare 'jshint' executable for JavaScript linting
+  - npm install jshint
 
 script:
   # Load database schema
@@ -22,6 +24,8 @@ script:
   - bundle exec rubocop
   # SCSS analyzer
   - bundle exec scss-lint
+  # JavaScript analyzer
+  - jshint ./app
 
 cache: bundler
 

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -1,8 +1,8 @@
 
 // Gives us a capitalize method
 String.prototype.capitalize = function() {
-    return this.charAt(0).toUpperCase() + this.slice(1);
-}
+  return this.charAt(0).toUpperCase() + this.slice(1);
+};
 
 var Helpy = Helpy || {};
 Helpy.admin = function(){
@@ -86,13 +86,13 @@ Helpy.admin = function(){
       $("div.select").removeClass("has-success").addClass("has-error");
       $("select").next().removeClass("glyphicon-ok").addClass("glyphicon-remove");
       $("div.select .glyphicon-ok").remove();
-      $("<span class='help-block'>can't be blank</span>").insertAfter("div.select .glyphicon-remove")
+      $("<span class='help-block'>can't be blank</span>").insertAfter("div.select .glyphicon-remove");
       $('input[type="submit"]').prop('disabled', true);
     }
     else{
      $('input[type="submit"]').prop('disabled', false); 
     }
-  })
+  });
 
 };
 
@@ -103,11 +103,11 @@ Helpy.showPanel = function(panel) {
   $('li.step-' + currentPanel).html("<span class='glyphicon glyphicon-ok'></span>").addClass('filled-circle');
   $('li.step-' + panel).addClass('active-step');
   return true;
-}
+};
 
 window.closeModal = function() {
   $('#modal').modal('hide');
-}
+};
 
 Helpy.showGrid = function() {
   // Clean up any select-styled links
@@ -119,6 +119,6 @@ Helpy.showGrid = function() {
 
   $('h2#setting-header').text('Settings');
 
-}
+};
 
 $(document).on('page:change', Helpy.admin);

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -82,7 +82,7 @@ Helpy.admin = function(){
   });
 
   $("#new_doc select, #edit_doc select").focusout(function(){
-    if($(this).val() == ""){
+    if($(this).val() === ""){
       $("div.select").removeClass("has-success").addClass("has-error");
       $("select").next().removeClass("glyphicon-ok").addClass("glyphicon-remove");
       $("div.select .glyphicon-ok").remove();

--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -1,3 +1,5 @@
+/*jshint multistr: true */
+
 var Helpy = Helpy || {};
 
 Helpy.ready = function(){
@@ -31,15 +33,15 @@ Helpy.ready = function(){
 
   $.ui.autocomplete.prototype._renderItem = function( ul, item) {
     return $( "<li></li>" )
-        .data( "item.autocomplete", item["name"] )
-        .append( "<div class='ui-menu-item-heading'><a href="+item["link"]+" >" + item["name"] + "</a></div>" )
-        .append( "<div class='ui-menu-item-content' >"+item["content"]+"</div>" )
+        .data( "item.autocomplete", item.name )
+        .append( "<div class='ui-menu-item-heading'><a href=" + item.link + " >" + item.name + "</a></div>" )
+        .append( "<div class='ui-menu-item-content' >" + item.content + "</div>" )
         .appendTo( ul );
   };
   
   
   $(".autosearch").keyup(function () {
-      var that = $(this)
+      var that = $(this);
       value = $(this).val();
       $(this).autocomplete({
         source: function (request, response) {
@@ -52,10 +54,10 @@ Helpy.ready = function(){
         minLength: 3,
         appendTo: that.next(),
         focus: function( event, ui ) {
-          $(".autosearch").val(ui["item"]["name"]);
+          $(".autosearch").val(ui.item.name);
         },
         select: function( event, ui ) {
-          window.location.href = ui["item"]["link"];
+          window.location.href = ui.item.link;
         },
         messages: {
           noResults: '',
@@ -119,7 +121,7 @@ Helpy.ready = function(){
   // used by create topic form
   $('#topic_private_true').click(function(){
     $("#topic_forum_id").parent().hide();
-    $('#new_topic').append("<input type='hidden' id='new_topic_forum_id' name='topic[forum_id]' value='1'/>")
+    $('#new_topic').append("<input type='hidden' id='new_topic_forum_id' name='topic[forum_id]' value='1'/>");
   });
   $('#topic_private_false').click(function(){
     $("#topic_forum_id").parent().show();
@@ -127,10 +129,10 @@ Helpy.ready = function(){
   });
 
   // Hide/replace last child of breadcrumbs since I don't have time to hack gem right now
-  $("ul.breadcrumb li:last-child").html("")
+  $("ul.breadcrumb li:last-child").html("");
 
   // compress thread if there are more than 4 messages
-  var $thread = $('.post-container.kind-reply.disallow-post-voting, .post-container.kind-note.disallow-post-voting')
+  var $thread = $('.post-container.kind-reply.disallow-post-voting, .post-container.kind-note.disallow-post-voting');
   if ($thread.size() >= 2) {
 
     // insert expand thread message
@@ -178,7 +180,7 @@ Helpy.ready = function(){
         break;
     }
     $('.selected-message').text(output);
-  };
+  }
 
   $('#check-all').off().on('change', function(){
     if (this.checked) {
@@ -216,7 +218,7 @@ Helpy.ready = function(){
     });
     // modify link to include array
     $.each(topic_ids, function(i){
-      str = str + "&topic_ids[]=" + topic_ids[i]
+      str = str + "&topic_ids[]=" + topic_ids[i];
     });
     $(this).attr('href', str);
     // return true to follow the link
@@ -248,7 +250,7 @@ Helpy.ready = function(){
     $('.forgot-form').hide();
     $('.modal-title').text($('.login-form').data("title"));
     $('.modal-links').show();
-  })
+  });
 
   $('.forgot-link').off().on('click', function() {
     $('.login-form').hide();
@@ -318,7 +320,7 @@ Helpy.didthisHelp = function(yesno){
 
   $('#did-this-help').html(message);
   return true;
-}
+};
 
 $(document).ready(Helpy.ready);
 $(document).on('page:load', Helpy.ready);
@@ -339,7 +341,7 @@ $(document).on('page:change', function () {
   // Allows image insertion into quill editor
   $('.doc-form-files .cloudinary-fileupload').bind('cloudinarydone', function(e, data) {
     var element = document.querySelector("trix-editor");
-    var thisImage = "<img src='" + $.cloudinary.image(data.result.public_id).attr('src') + "'>"
+    var thisImage = "<img src='" + $.cloudinary.image(data.result.public_id).attr('src') + "'>";
     element.editor.insertHTML(thisImage);
 
     $('.image_public_id').val(data.result.public_id);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -70,7 +70,7 @@
           obj.find('.truncate_more').css("display", "none");
 
           // insert more link
-          $('<a href="#" class="truncate_more_link">' + options.moreText + '</a>').insertAfter(obj.find('.truncate_more'))
+          $('<a href="#" class="truncate_more_link">' + options.moreText + '</a>').insertAfter(obj.find('.truncate_more'));
         }
       } // end if
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -43,7 +43,7 @@
 // modified by Scott Miller- remove animation, newline for more link
 
 (function($){
-  $.fn.jTruncate = function(options) {
+  $.fn.jTruncate = function(opts) {
     var defaults = {
       length: 300,
       minTrail: 20,
@@ -52,7 +52,7 @@
       ellipsisText: "..."
     };
 
-    var options = $.extend(defaults, options);
+    var options = $.extend(defaults, opts);
 
     return this.each(function() {
       obj = $(this);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -62,7 +62,6 @@
         var splitLocation = body.indexOf(' ', options.length);
         if(splitLocation != -1) {
           // truncate tip
-          var splitLocation = body.indexOf(' ', options.length);
           var str1 = body.substring(0, splitLocation);
           var str2 = body.substring(splitLocation, body.length - 1);
           obj.html(str1 + '<span class="truncate_ellipsis">' + options.ellipsisText +

--- a/app/assets/javascripts/event-tracking.js
+++ b/app/assets/javascripts/event-tracking.js
@@ -51,7 +51,7 @@ Helpy.track = function(){
 
   $('.label-collapsed').off().on("click", function(){
     ga('send', 'event', 'Inpage-Nav','Click', 'Show Hidden');
-  })
+  });
 
   $('.topic-box').on("click", function(){
     ga('send', 'event', 'Inpage-Nav','Click', $(this).find('h5').text());

--- a/app/assets/javascripts/rails.validations.callbacks.js
+++ b/app/assets/javascripts/rails.validations.callbacks.js
@@ -5,7 +5,7 @@ window.ClientSideValidations.callbacks.element.fail = function(element, message,
   parent.find('span.glyphicon-ok').remove();
   parent.addClass('has-feedback').addClass('has-error').removeClass('has-success');
   element.after('<span class="glyphicon glyphicon-remove form-control-feedback" aria-hidden="true"></span>');
-}
+};
 
 window.ClientSideValidations.callbacks.element.pass = function(element, callback) {
   callback();
@@ -15,4 +15,4 @@ window.ClientSideValidations.callbacks.element.pass = function(element, callback
   parent.find('help-block').remove();
   parent.find('span.glyphicon-remove').remove();
   element.after('<span class="glyphicon glyphicon-ok form-control-feedback" aria-hidden="true"></span>');
-}
+};

--- a/app/assets/javascripts/widget.v1.js
+++ b/app/assets/javascripts/widget.v1.js
@@ -14,7 +14,7 @@
     var allScripts = document.getElementsByTagName('script');
     var targetScripts = [];
     for (var i in allScripts) {
-        var name = allScripts[i].src
+        var name = allScripts[i].src;
         if(name && name.indexOf(scriptName) > 0)
             targetScripts.push(allScripts[i]);
     }

--- a/app/themes/flat/assets/javascripts/flat/sidr.js
+++ b/app/themes/flat/assets/javascripts/flat/sidr.js
@@ -1,3 +1,5 @@
+// jshint ignore: start
+
 /*! sidr - v2.2.1 - 2016-02-17
  * http://www.berriart.com/sidr/
  * Copyright (c) 2013-2016 Alberto Varela; Licensed MIT */

--- a/app/themes/light/assets/javascripts/light/sidr.js
+++ b/app/themes/light/assets/javascripts/light/sidr.js
@@ -1,3 +1,5 @@
+// jshint ignore: start
+
 /*! sidr - v2.2.1 - 2016-02-17
  * http://www.berriart.com/sidr/
  * Copyright (c) 2013-2016 Alberto Varela; Licensed MIT */

--- a/app/views/result/index.js
+++ b/app/views/result/index.js
@@ -1,4 +1,4 @@
-$('#results-found').html("<%= escape_javascript(render('results_found')) %>")
+$('#results-found').html("<%= escape_javascript(render('results_found')) %>");
 $('#search-results').html("<%= escape_javascript(render('search_results')) %>");
 // Need to report search to google here too
 


### PR DESCRIPTION
I noticed [JSHint](http://jshint.com/) isn't being run on the app's JavaScript code. The tool really helps keep things clean and error-free, as well as enforcing some style conventions (such as use of semi-colon).

All rules can be disabled (globally, or per-file) if required, but I've stuck with the default configuration for now.