### PR TITLE
Fix no _ga cookies.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,7 +41,7 @@ class ApplicationController < ActionController::Base
   end
 
   def tracker(ga_category, ga_action, ga_label, ga_value=nil)
-    if AppSettings['settings.google_analytics_id'].present?
+    if AppSettings['settings.google_analytics_id'].present? && cookies['_ga'].present?
       ga_cookie = cookies['_ga'].split('.')
       ga_client_id = ga_cookie[2] + '.' + ga_cookie[3]
       logger.info("Enqueing job for #{ga_client_id}")


### PR DESCRIPTION
When I use the site with ghostery or no google analytics cookie:
```
2016-08-08T15:19:34.387910+00:00 app[web.1]: Completed 500 Internal Server Error in 64ms (ActiveRecord: 27.4ms)
2016-08-08T15:19:34.392459+00:00 app[web.1]:
2016-08-08T15:19:34.392461+00:00 app[web.1]: NoMethodError (undefined method `split' for nil:NilClass):
2016-08-08T15:19:34.392462+00:00 app[web.1]:   app/controllers/application_controller.rb:45:in `tracker'
2016-08-08T15:19:34.392463+00:00 app[web.1]:   app/controllers/admin/topics_controller.rb:57:in `index'
2
```