### PR TITLE
Update acts-as-taggable-on to 4.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ gem 'http_accept_language'
 gem 'permalink_fu'
 gem 'paper_trail'
 
-gem 'acts-as-taggable-on', '~>3.5'
+gem 'acts-as-taggable-on', '~> 4.0'
 
 gem 'kaminari'
 gem 'kaminari-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,8 +44,8 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    acts-as-taggable-on (3.5.0)
-      activerecord (>= 3.2, < 5)
+    acts-as-taggable-on (4.0.0)
+      activerecord (>= 4.0)
     addressable (2.4.0)
     annotate (2.7.0)
       activerecord (>= 3.2, < 6.0)
@@ -502,7 +502,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  acts-as-taggable-on (~> 3.5)
+  acts-as-taggable-on (~> 4.0)
   annotate
   attachinary
   awesome_print


### PR DESCRIPTION
Adds support for Rails 5.

Changelog: https://github.com/mbleigh/acts-as-taggable-on/compare/v3.5.0...v4.0.0

Fixes #233 
