### PR TITLE
Fixes #305

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -28,7 +28,8 @@ module AdminHelper
           select += "<optgroup label='#{I18n.translate("i18n_languages.#{locale}")}'>"
         end
         Doc.replies.with_translations(locale).all.each do |doc|
-          select += "<option value=\"#{strip_tags(doc.body)}\"}{>#{doc.title}</option>"
+            body = (strip_tags(doc.body)).gsub(/\'/, '&#39;')
+            select += "<option value='#{body}'>#{doc.title}</option>"
         end
         select += "</optgroup>"
       end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -28,7 +28,7 @@ module AdminHelper
           select += "<optgroup label='#{I18n.translate("i18n_languages.#{locale}")}'>"
         end
         Doc.replies.with_translations(locale).all.each do |doc|
-          select += "<option value='#{strip_tags(doc.body)}'>#{doc.title}</option>"
+          select += "<option value=\"#{strip_tags(doc.body)}\"}{>#{doc.title}</option>"
         end
         select += "</optgroup>"
       end


### PR DESCRIPTION
The use of single quotes meant that common replies including the `'` character would not be correctly inputted as an `option`'s value, this fixes that.