### PR TITLE
Adjusting Helpy Turbolinks version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,8 +22,8 @@ gem 'client_side_validations'
 gem 'client_side_validations-simple_form'
 
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
-gem 'turbolinks'
-gem 'jquery-turbolinks'
+gem 'turbolinks', '~> 2.5.3'
+gem 'jquery-turbolinks', '~> 2.1.0'
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -614,7 +614,7 @@ DEPENDENCIES
   i18n-country-translations
   jbuilder (~> 2.0)
   jquery-rails
-  jquery-turbolinks
+  jquery-turbolinks (~> 2.1.0)
   jquery-ui-rails
   kaminari
   kaminari-i18n
@@ -664,15 +664,12 @@ DEPENDENCIES
   themes_on_rails
   timecop
   trix
-  turbolinks
+  turbolinks (~> 2.5.3)
   twitter-bootstrap-rails
   twitter-bootstrap-rails-confirm
   uglifier (>= 1.3.0)
   unicorn
   web-console (~> 2.0)
-
-RUBY VERSION
-   ruby 2.2.1p85
 
 BUNDLED WITH
    1.12.5


### PR DESCRIPTION
Keeping Turbolinks and jQuery Turbolinks dependencies on latest versions tested without issues. This PR is reference of #287.