### PR TITLE
Change New queue so it includes any unassigned topic

### DIFF
--- a/app/controllers/admin/topics_controller.rb
+++ b/app/controllers/admin/topics_controller.rb
@@ -59,7 +59,9 @@ class Admin::TopicsController < Admin::BaseController
 
   def show
     @topic = Topic.where(id: params[:id]).first
-    if @topic.current_status == 'new'
+
+    # REVIEW: Try not opening message on view unless assigned
+    if @topic.current_status == 'new' && @topic.assigned?
       tracker("Agent: #{current_user.name}", "Opened Ticket", @topic.to_param, @topic.id)
       @topic.open
     end
@@ -159,19 +161,19 @@ class Admin::TopicsController < Admin::BaseController
           @topics.bulk_reopen(bulk_post_attributes)
         when 'trash'
           @topics.bulk_trash(bulk_post_attributes)
-        end 
+        end
       else
         @topics.update_all(current_status: params[:change_status])
       end
-      
+
       @action_performed = "Marked #{params[:change_status].titleize}"
       # Calls to GA for close, reopen, assigned.
       tracker("Agent: #{current_user.name}", @action_performed, @topics.to_param, 0)
-      
+
     end
-    
+
     if params[:topic_ids].present?
-      @topic = Topic.find(params[:topic_ids].last) 
+      @topic = Topic.find(params[:topic_ids].last)
       @posts = @topic.posts.chronologic
     end
 
@@ -205,8 +207,8 @@ class Admin::TopicsController < Admin::BaseController
         # Calls to GA
         tracker("Agent: #{current_user.name}", "Assigned to #{assigned_user.name.titleize}", @topic.to_param, 0)
       end
-    end 
-    
+    end
+
     @topics.bulk_assign(bulk_post_attributes, assigned_user.id) if bulk_post_attributes.present?
 
     if params[:topic_ids].count > 1

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -51,7 +51,7 @@ class Topic < ActiveRecord::Base
   # various scopes
   scope :recent, -> { order('created_at DESC').limit(8) }
   scope :open, -> { where(current_status: "open") }
-  scope :unread, -> { where(current_status: "new") }
+  scope :unread, -> { where("assigned_user_id = ? OR current_status = ?", nil, "new").where.not(current_status: 'closed') }
   scope :pending, -> { where(current_status: "pending") }
   scope :mine, -> (user) { where(assigned_user_id: user) }
   scope :closed, -> { where(current_status: "closed") }
@@ -85,6 +85,10 @@ class Topic < ActiveRecord::Base
 
   def email_subject
     "##{self.id} | #{self.name}"
+  end
+
+  def assigned?
+    self.assigned_user_id.present?
   end
 
   def open?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -113,6 +113,10 @@ class User < ActiveRecord::Base
       self.settings.notify_on_private = "1"
       self.settings.notify_on_public = "1"
       self.settings.notify_on_reply = "1"
+    else
+      self.settings.notify_on_private = nil
+      self.settings.notify_on_public = nil
+      self.settings.notify_on_reply = nil     
     end
   end
 

--- a/test/controllers/admin/topics_controller_test.rb
+++ b/test/controllers/admin/topics_controller_test.rb
@@ -157,16 +157,19 @@ class Admin::TopicsControllerTest < ActionController::TestCase
       end
     end
 
-    test "an #{admin}viewing a new discussion should change the status to PENDING" do
-      sign_in users(admin.to_sym)
-      @ticket = Topic.find(6)
-
-      xhr :get, :show, { id: @ticket.id }
-
-      #reload object:
-      @ticket = Topic.find(6)
-      assert @ticket.current_status == "pending", "ticket status did not change to pending"
-    end
+    # NOTE: THIS BEHAVIOR WAS REVERSED BASED ON USER FEEDBACK THAT IT WAS HARD TO
+    # FIND DISCUSSIONS AFTER THEY WERE VIEWED, LEFT TEST JUST IN CASE 
+    #
+    # test "an #{admin}viewing a new discussion should change the status to PENDING" do
+    #   sign_in users(admin.to_sym)
+    #   @ticket = Topic.find(6)
+    #
+    #   xhr :get, :show, { id: @ticket.id }
+    #
+    #   #reload object:
+    #   @ticket = Topic.find(6)
+    #   assert @ticket.current_status == "pending", "ticket status did not change to pending"
+    # end
   end
 
   %w(user editor).each do |unauthorized|

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -221,16 +221,16 @@ class UserTest < ActiveSupport::TestCase
     assert_equal u.settings.notify_on_reply, "1"
   end
 
-  test "An user should NOT be enabled for notifications after they are created" do
+  test "A user should NOT be enabled for notifications after they are created" do
     u = User.create!(
       email: 'user@temp.com',
       name: 'test user',
       password: '12345678',
       role: 'user'
     )
-    assert_equal u.settings.notify_on_private, nil
-    assert_equal u.settings.notify_on_public, nil
-    assert_equal u.settings.notify_on_reply, nil
+    assert_equal nil, u.settings.notify_on_private, "Should not be enabled for private notifications"
+    assert_equal nil, u.settings.notify_on_public, "Should not be enabled for public notifications"
+    assert_equal nil, u.settings.notify_on_reply, "Should not be enabled for reply notifications"
 
   end
 


### PR DESCRIPTION
This is based on customer feedback that it is confusing when unassigned tickets do not show up in the "New" queue.  So with this PR, the New queue will now include unassigned tickets, and tickets with status of new that are assigned.