### PR TITLE
Refactor of tickets table rows, to normalize the layout

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -259,8 +259,12 @@ a.stats.active {
 	margin-top: 13px !important;
 }
 
+.topic time {
+	padding-top: 0;
+}
+
 .topic span.label-count {
-	margin-top: -11px;
+	margin-top: -4px;
 	margin-right: 10px;
 	margin-left:10px;
 }

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -263,8 +263,10 @@ a.stats.active {
 	padding-top: 0;
 }
 
+.status-label {
+	margin: 5px 0px 0px 5px;
+}
 .topic span.label-count {
-	margin-top: -4px;
 	margin-right: 10px;
 	margin-left:10px;
 }

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -138,8 +138,7 @@ textarea {
 }
 
 .topic time {
-  display: table-cell;
-  padding-top: 3px;
+  line-height: 25px;
 }
 
 #page-title {
@@ -296,18 +295,18 @@ div.admin-tools {
 
 .label-count {
 	position: relative;
-	top:  -0.2em;
 	border: 1px solid #999;
 	background-color: #fff;
 	color: #999;
-  	display: inline;
-  	font-size: 100%;
-  	font-weight: normal;
-  	line-height: 1;
-  	text-align: center;
-  	white-space: nowrap;
-  	vertical-align: baseline;
-  	border-radius: .25em;
+	display: inline;
+	font-size: 100%;
+	font-weight: normal;
+	line-height: 1;
+  margin-top: -1px;
+	text-align: center;
+	white-space: nowrap;
+	vertical-align: baseline;
+	border-radius: .25em;
 }
 
 .active {
@@ -328,6 +327,7 @@ div.admin-tools {
 span.more-important a {
 	font-weight: bold;
 	font-size: 105%;
+  vertical-align: middle;
 }
 
 span.more-important a:link {

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -26,12 +26,12 @@
 
 module TopicsHelper
 
-  def badge_for_status(status)
-    content_tag(:span, status_label(status).upcase, class: "hidden-xs pull-right status-label label #{status_class(status)}")
+  def badge_for_status(status, badge_orientation = "right")
+    content_tag(:span, status_label(status).upcase, class: "hidden-xs pull-#{badge_orientation} status-label label #{status_class(status)}")
   end
 
-  def badge_for_private
-    content_tag(:span, t(:private, default: 'PRIVATE').upcase, class: 'hidden-xs pull-right status-label label label-private')
+  def badge_for_private(badge_orientation = "right")
+    content_tag(:span, t(:private, default: 'PRIVATE').upcase, class: "hidden-xs pull-#{badge_orientation} status-label label label-private")
   end
 
   def control_for_status(status)

--- a/app/views/admin/topics/_tickets.html.erb
+++ b/app/views/admin/topics/_tickets.html.erb
@@ -5,11 +5,13 @@
 
   <col width="80px" class="checkbox-col">
   <col>
-  <col width="20%" class="hidden-xs">
+  <col width="25%" class="hidden-xs">
+  <col width="15%" class="hidden-xs">
 
   <tr>
     <th><%= check_box_tag 'check-all' %></th>
     <th><%= t(:subject, default: "Subject") %></th>
+    <th></th>
     <th class="text-right hidden-xs"><%= t(:last_activity, default: "Last Active") %></th>
   </tr>
   <tbody>

--- a/app/views/admin/topics/_topic.html.erb
+++ b/app/views/admin/topics/_topic.html.erb
@@ -8,7 +8,7 @@
 
   <td>
     <span class="topic-link more-important truncate-ellipsis">
-      <%= link_to "##{topic.id}- #{topic.name}", admin_topic_path(topic), remote: true -%><%= badge_for_status(topic.current_status) %><%= badge_for_private if topic.private? %>
+      <%= link_to "##{topic.id}- #{topic.name}", admin_topic_path(topic), remote: true -%>
     </span>
     <span class="less-important user-link">
       <%= link_to t(:started_by, username: topic.user.name? ? topic.user.name.titleize : topic.user.email, default: "Started by #{topic.user.name? ? topic.user.name.titleize : topic.user.email}"), admin_user_path(topic.user.id), remote: true %>
@@ -17,7 +17,11 @@
   </td>
 
   <td class="last-active less-important text-right hidden-xs">
-    <span class="label label-count hidden-xs pull-left"><%= topic.posts_count %></span>
+    <%= badge_for_status(topic.current_status, "left") %>
+    <%= badge_for_private("left") if topic.private? %>
+    <span class="label label-count hidden-xs pull-right"><%= topic.posts_count %></span>
+  </td>
+  <td class="last-active less-important text-right hidden-xs">
     <%= last_active_time(topic.updated_at) %>
   </td>
 </tr>

--- a/app/views/topics/_ticket.html.erb
+++ b/app/views/topics/_ticket.html.erb
@@ -10,7 +10,7 @@
 <tr class="topic border-bottom">
   <td>
     <span class="topic-link truncate-ellipsis more-important">
-      <%= link_to "##{ticket.id}- #{ticket.name.capitalize}", ticket_path(ticket) -%>
+      <%= link_to "##{ticket.id} - #{ticket.name.capitalize}", ticket_path(ticket) -%>
       <%= badge_for_status(ticket.current_status) %>
     </span>
   </td>


### PR DESCRIPTION
Adjusting the admin table rows layout that PR #320 was broken in same time that fix other sector fo Helpy.

Here is a PR that normalize the layout refactoring some helpers (has a fallback support of use), HTML structure, and adjusting some CSS rules.

I made a new PR, because I made some other changes here.

Here's a screenshot after refactor:
![selecao_007](https://cloud.githubusercontent.com/assets/5271543/18573550/c8998402-7b9a-11e6-9179-35dfefc68127.png)
