### PR TITLE
Enhance support for local SMTP servers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -110,11 +110,12 @@ class ApplicationController < ActionController::Base
     Griddler.configuration.email_service = AppSettings["email.mail_service"].present? ? AppSettings["email.mail_service"].to_sym : :sendgrid
 
     ActionMailer::Base.smtp_settings = {
-        :address   => AppSettings["email.mail_smtp"],
-        :port      => AppSettings["email.mail_port"],
-        :user_name => AppSettings["email.smtp_mail_username"],
-        :password  => AppSettings["email.smtp_mail_password"],
-        :domain    => AppSettings["email.mail_domain"]
+        :address              => AppSettings["email.mail_smtp"],
+        :port                 => AppSettings["email.mail_port"],
+        :user_name            => AppSettings["email.smtp_mail_username"].presence,
+        :password             => AppSettings["email.smtp_mail_password"].presence,
+        :domain               => AppSettings["email.mail_domain"],
+        :enable_starttls_auto => !AppSettings["email.mail_smtp"].in?(["localhost", "127.0.0.1", "::1"])
     }
 
     ActionMailer::Base.perform_deliveries = to_boolean(AppSettings['email.send_email'])

--- a/config/initializers/mail.rb
+++ b/config/initializers/mail.rb
@@ -1,7 +1,0 @@
-ActionMailer::Base.smtp_settings = {
-    :address   => Settings.mail_smtp,
-    :port      => Settings.mail_port,
-    :user_name => Settings.smtp_mail_username,
-    :password  => Settings.smtp_mail_password,
-    :domain    => Settings.mail_domain
-}


### PR DESCRIPTION
A common way for sending emails is to use a local SMTP server, most often not requiring
authentication and TLS and providing TLS only with a self-signed certificate (this is, for example,
the default configuration for Postfix on Debian/Ubuntu). Thus, skip authentication if no SMTP
credentials are set and disable TLS if the SMTP address is set to localhost. Along the way remove
the obsolete mail initializer.
