### PR TITLE
Group enhancements

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -49,6 +49,24 @@ Helpy.admin = function(){
     return false;
   });
 
+  // You have to delegate this to the document or it does not work reliably
+  // See http://stackoverflow.com/questions/18545941/jquery-on-submit-event
+  $(document).on('submit','form.new-group-form', function(){
+    var $field = $('#new_group');
+    var newGroup = $field.val();
+    var $newItem = $('<li/>');
+    var $newLink = $('<a class="link-tag" data-remote="true" href="/admin/topics/assign_team?team=' + newGroup + '&topic_ids[]=' + Helpy.topicID + '"><div class="color-sample label-' + newGroup.charAt(0).toLowerCase() + '"></div> <div>' + newGroup + '</div></a></li>');
+    //var $newLink = $('<a data-remote="true" href="/admin/topics/assign_team?team=' + newGroup + '"><div class="color-sample label-' + newGroup.charAt(0).toLowerCase() + '"></div> <div>' + newGroup + '</div></a>');
+    // if ($field.hasClass('multiple')) {
+      // $newLink.addClass('multiple-update');
+    // }
+
+    $('.new-tag').before($newItem.append($newLink));
+    $('#new_group').val('');
+    $('.link-tag').off().click();
+    return false;
+  });
+
   $('.pick-a-color').minicolors({
     theme: 'bootstrap'
   });

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -356,7 +356,15 @@ ul.settings-menu {
   border: 1px solid rgba(0, 0, 0, .2);
 }
 
+.new-tag {
+	margin-left: 20px;
+	margin-top: 10px;
+	margin-bottom: 10px;
 
+	input {
+		width: 90%;
+	}
+}
 // === TEAM INSIGHTS ===
 
 .team-members {

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -2,6 +2,7 @@ class Admin::BaseController < ApplicationController
 
   layout 'admin'
   before_action :authenticate_user!
+  before_action :get_all_teams
   helper_method :show_onboarding?
 
   # Here we are just checking if the onboarding should be shown, based on the

--- a/app/controllers/admin/topics_controller.rb
+++ b/app/controllers/admin/topics_controller.rb
@@ -30,7 +30,6 @@ class Admin::TopicsController < Admin::BaseController
   before_action :fetch_counts, :only => ['index','show', 'update_topic', 'user_profile']
   before_action :pipeline, :only => ['index', 'show', 'update_topic']
   before_action :remote_search, :only => ['index', 'show', 'update_topic']
-  before_action :get_all_teams, only: 'new'
 
   respond_to :js, :html, only: :show
   respond_to :js

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -192,6 +192,7 @@ class ApplicationController < ActionController::Base
   end
 
   def get_all_teams
+    return unless teams?
     @all_teams = ActsAsTaggableOn::Tagging.all.where(context: "teams").map{|tagging| tagging.tag.name.capitalize }.uniq
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -90,7 +90,7 @@ module ApplicationHelper
   def tag_listing(tags, tagging_type = "message")
     return unless teams? or tagging_type == "doc"
     tags.each do |tag|
-      concat content_tag(:span, tag, class: "label label-#{tagging_type}-tagging label-#{tag.first} #{'pull-right' if tagging_type == 'message'}")
+      concat content_tag(:span, tag, class: "label label-#{tagging_type}-tagging label-#{tag.first.downcase} #{'pull-right' if tagging_type == 'message'}")
     end
   end
 

--- a/app/views/admin/topics/_new_ticket.html.erb
+++ b/app/views/admin/topics/_new_ticket.html.erb
@@ -5,7 +5,7 @@
     <%= u.input :name, class: 'disable-empty' %>
   <% end %>
   <%= f.input :name, :size => 40, class: 'disable-empty' -%>
-  <%= f.input(:team_list, collection: @all_teams, :label => t(:assign_to), locale: I18n.locale, prompt: "", style: "display:none;") if teams? %>
+  <%= f.input(:team_list, collection: @all_teams, :label => t(:assign_to), locale: I18n.locale, prompt: "", style: "display:none;") if teams? and @all_teams.count > 0 %>
   <%= f.simple_fields_for @topic.posts.new do |i| %>
     <%= i.input :body, input_html: { rows: 8, cols: 60, class: 'disable-empty form-control' }, label: false, validate: { presence: true } -%>
   <% end %>

--- a/app/views/admin/topics/_tickets.html.erb
+++ b/app/views/admin/topics/_tickets.html.erb
@@ -45,6 +45,7 @@
             </ul>
           </span>
 
+          <% if teams? and @all_teams.count > 0 %>
           <span class="btn btn-group left-col-dropdown">
             <span class="dropdown-toggle ticket-control tiny-header" data-toggle="dropdown" aria-expanded="false">
               <%= t(:no_team_assigned, default: 'Assign to group') %> <span class='caret'></span>
@@ -59,7 +60,8 @@
 
             </ul>
           </span>
-
+          <% end %>
+          
         </span>
       </td>
     </tr>

--- a/app/views/admin/topics/_tickets.html.erb
+++ b/app/views/admin/topics/_tickets.html.erb
@@ -52,16 +52,21 @@
             </span>
             <ul class="dropdown-menu ticket-controls" role="menu">
               <% @all_teams.to_a.each do |team| %>
-              <li>
+              <li class='team-item'>
                 <%= link_to("#{content_tag(:div, '', class: 'color-sample label-' + team.first.downcase)} #{content_tag :div, team.try(:titleize)}".html_safe, admin_assign_team_path(team: team), :remote => true, class: 'multiple-update') %>
               </li>
               <% end %>
-              <li><%= link_to "Unassign from group", admin_assign_team_path(team: ''), :remote => true %></li>
+              <!-- <li class="new-tag">
+                <%= form_tag '#', class: 'new-group-form', remote: true do %>
+                <%= text_field_tag "new_group", '', placeholder: "Add a new group", class: 'form-control multiple' %><%#= link_to "Add", '#', class: 'btn btn-default pull-right add-new-group' %>
+                <% end %>
+              </li> -->
+              <li><%= link_to "Unassign from group", admin_assign_team_path(team: ''), remote: true, class: 'multiple-update' %></li>
 
             </ul>
           </span>
           <% end %>
-          
+
         </span>
       </td>
     </tr>

--- a/app/views/admin/topics/_topic.html.erb
+++ b/app/views/admin/topics/_topic.html.erb
@@ -9,9 +9,6 @@
   <td>
       <span class="topic-link more-important truncate-ellipsis">
         <%= link_to "##{topic.id}- #{topic.name}", admin_topic_path(topic), remote: true -%><%= badge_for_status(topic.current_status) %><%= badge_for_private if topic.private? %><% tag_listing(topic.team_list) %>
-
-        <% # if topic.team_list.length > 0 %>
-        <% # end %>
       </span>
     <span class="less-important user-link">
       <%= link_to t(:started_by, username: topic.user.name? ? topic.user.name.titleize : topic.user.email, default: "Started by #{topic.user.name? ? topic.user.name.titleize : topic.user.email}"), admin_user_path(topic.user.id), remote: true %>

--- a/app/views/admin/topics/_topic_options.html.erb
+++ b/app/views/admin/topics/_topic_options.html.erb
@@ -39,7 +39,7 @@
   </span>
 
   <%# if @topic.team_list.length > 0 or teams? %>
-  <% if teams? %>
+  <% if teams? and @all_teams.count > 0 %>
     <span class="status btn-group left-col-dropdown">
       <span class="dropdown-toggle ticket-control" data-toggle="dropdown" aria-expanded="false">
         <%= content_tag(:span, class: "btn status-label label label-#{@topic.team_list.present? ? @topic.team_list.first.first : 'default'}") do %>

--- a/app/views/admin/topics/_topic_options.html.erb
+++ b/app/views/admin/topics/_topic_options.html.erb
@@ -1,3 +1,6 @@
+<script>
+  Helpy.topicID = <%= @topic.id %>;
+</script>
 <span class="btn-group left-col-dropdown">
   <span class="status dropdown-toggle ticket-control" data-toggle="dropdown" aria-expanded="false">
     <%= control_for_status(@topic.current_status) %>
@@ -38,23 +41,27 @@
     </ul>
   </span>
 
-  <%# if @topic.team_list.length > 0 or teams? %>
-  <% if teams? and @all_teams.count > 0 %>
+  <% if teams? %>
     <span class="status btn-group left-col-dropdown">
       <span class="dropdown-toggle ticket-control" data-toggle="dropdown" aria-expanded="false">
-        <%= content_tag(:span, class: "btn status-label label label-#{@topic.team_list.present? ? @topic.team_list.first.first : 'default'}") do %>
+        <%= content_tag(:span, class: "btn status-label label label-#{@topic.team_list.present? ? @topic.team_list.first.first.downcase : 'default'}") do %>
           <%= @topic.team_list.first.try(:upcase) || t(:no_team_assigned, default: 'Assign to group') %>
           <%= icon('caret-down') + ' ' %>
         <% end %>
       </span>
-      <ul class="dropdown-menu ticket-controls" role="menu">
+      <ul class="dropdown-menu ticket-controls team-list" role="menu">
         <% @all_teams.to_a.each do |team| %>
-          <li>
+          <li class='team-item'>
             <% unless @topic.current_status == "closed" %>
               <%= link_to("#{content_tag(:div, '', class: 'color-sample label-' + team.first.downcase)} #{content_tag :div, team.try(:titleize)}".html_safe, admin_assign_team_path(topic_ids: { "":@topic.id }, team: team), :remote => true) %>
             <% end %>
           </li>
         <% end %>
+        <li class="new-tag">
+          <%= form_tag '#', class: 'new-group-form' do %>
+          <%= text_field_tag "new_group", '', placeholder: "Add a new group", class: 'form-control' %><%#= link_to "Add", '#', class: 'btn btn-default pull-right add-new-group' %>
+          <% end %>
+        </li>
         <li><%= link_to "Unassign from group", admin_assign_team_path(topic_ids: { "":@topic.id }, team: ''), :remote => true unless @topic.current_status == "closed" %></li>
 
       </ul>

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -47,7 +47,7 @@
     </script>
     <% end %>
 
-    <%= f.input(:team_list, collection: @all_teams, :label => t(:assign_to), locale: I18n.locale, prompt: "", style: "display:none;") if teams? and !@widget %>
+    <%= f.input(:team_list, collection: @all_teams, :label => t(:assign_to), locale: I18n.locale, prompt: "", style: "display:none;") if teams? and !@widget and @all_teams.count > 0 %>
     <%= f.input :name, input_html: { value: params[:q] }, :size => 40,  placeholder: I18n.t(:subject), label: I18n.t(:subject), class: 'disable-empty topic-placeholder' %>
 
     <div class="suggestion-results-container hidden">


### PR DESCRIPTION
This prevents the groups dropdown from appearing if there are no groups, and adds a form to the discussion options dropdown.  Also moved the `get_all_teams` before_action into the admin base controller so it is globally set across the admin.