### PR TITLE
 Add scalingo one click deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec unicorn_rails -p $PORT -c ./config/unicorn.rb
+postdeploy: bundle exec rake db:setup

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Installation
 
 Helpy was designed to run on on modern cloud providers like Digital Ocean or Heroku, although it should work just about anywhere.  For a quick trial you can get set up on Heroku by clicking this button:
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+[![Deploy on Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+[![Deploy on Scalingo](https://cdn.scalingo.com/deploy/button.svg)](https://my.scalingo.com/deploy)
 
 Requirements are:
 

--- a/scalingo.json
+++ b/scalingo.json
@@ -5,5 +5,6 @@
 	"ref": "staging",
 	"website": "https://helpy.io",
 	"logo": "https://helpy.io/images/logo.png",
-	"addons": ["scalingo-postgresql"]
+	"addons": ["scalingo-postgresql"],
+	"success_url": "/admin"
 }

--- a/scalingo.json
+++ b/scalingo.json
@@ -1,0 +1,9 @@
+{
+	"name": "Helpy Support",
+	"description": "An Open Source Help Desk",
+	"repository": "https://github.com/EtienneM/helpy",
+	"ref": "staging",
+	"website": "https://helpy.io",
+	"logo": "https://helpy.io/images/logo.png",
+	"addons": ["scalingo-postgresql"]
+}


### PR DESCRIPTION
Add a link to deploy in one click to the Scalingo platform. Scalingo is a PaaS that supports Rails pretty well.

These changes add the scalingo.json file to provide deployment information to Scalingo and add a _Deploy to Scalingo_ button on the README.md.
