### PR TITLE
Add ability to insert custom javascript through settings

### DIFF
--- a/app/themes/flat/views/layouts/flat.html.erb
+++ b/app/themes/flat/views/layouts/flat.html.erb
@@ -5,8 +5,9 @@
 		<%= render partial: 'layouts/head' %>
 		<link rel="stylesheet" href="//cdn.jsdelivr.net/jquery.sidr/2.2.1/stylesheets/jquery.sidr.dark.min.css">
 		<%= css_injector %>
+		<%= "#{AppSettings['design.header_js']}".html_safe %>
 	</head>
-<body>
+	<body class="<%= controller_name %>-<%= action_name %>" data-locale="<%= I18n.locale %>">
 	<script>
 	  ga('set', 'location', location.href.split('#')[0]);
 	  ga('send', 'pageview', { "title": document.title });
@@ -108,6 +109,7 @@ $('#right-menu').sidr({
 $('ul.nav').off().on('click', function(){
  $.sidr('close', 'nav');
 });
+<%= "#{AppSettings['design.footer_js']}".html_safe %>
 </script>
 
 

--- a/app/themes/flat/views/layouts/flat.html.erb
+++ b/app/themes/flat/views/layouts/flat.html.erb
@@ -109,8 +109,8 @@ $('#right-menu').sidr({
 $('ul.nav').off().on('click', function(){
  $.sidr('close', 'nav');
 });
-<%= "#{AppSettings['design.footer_js']}".html_safe %>
 </script>
+<%= "#{AppSettings['design.footer_js']}".html_safe %>
 
 
 </body>

--- a/app/themes/helpy/views/layouts/helpy.html.erb
+++ b/app/themes/helpy/views/layouts/helpy.html.erb
@@ -6,9 +6,10 @@
 		<%= rtl_tags if rtl? %>
 		<%= css_overrides %>
 		<%= css_injector %>
+		<%= "#{AppSettings['design.header_js']}".html_safe %>
 	</head>
 
-<body class="<%= 'rtl' if rtl? %>">
+<body class="<%= 'rtl' if rtl? %> <%= controller_name %>-<%= action_name %>" data-locale="<%= I18n.locale %>">
 <script>
   ga('set', 'location', location.href.split('#')[0]);
   ga('send', 'pageview', { "title": document.title });
@@ -64,5 +65,7 @@
 	</div>
 </div>
 <%= "<script src='/assets/widget.v1.js'></script>".html_safe if AppSettings['widget.show_on_support_site'] == '1' %>
+
+<%= "<script>\n#{AppSettings['design.footer_js']}\n</script>".html_safe %>
 </body>
 </html>

--- a/app/themes/helpy/views/layouts/helpy.html.erb
+++ b/app/themes/helpy/views/layouts/helpy.html.erb
@@ -65,7 +65,6 @@
 	</div>
 </div>
 <%= "<script src='/assets/widget.v1.js'></script>".html_safe if AppSettings['widget.show_on_support_site'] == '1' %>
-
-<%= "<script>\n#{AppSettings['design.footer_js']}\n</script>".html_safe %>
+<%= "#{AppSettings['design.footer_js']}".html_safe %>
 </body>
 </html>

--- a/app/themes/light/views/layouts/light.html.erb
+++ b/app/themes/light/views/layouts/light.html.erb
@@ -5,8 +5,9 @@
 		<%= render partial: 'layouts/head' %>
 		<link rel="stylesheet" href="//cdn.jsdelivr.net/jquery.sidr/2.2.1/stylesheets/jquery.sidr.dark.min.css">
 		<%= css_injector %>
+		<%= "#{AppSettings['design.header_js']}".html_safe %>
 	</head>
-<body>
+<body class="<%#= (request.fullpath.gsub("/#{I18n.locale}/","").gsub("/","-")) %><%= controller_name %>-<%= action_name %>" data-locale="<%= I18n.locale %>">
 	<script>
 	  ga('set', 'location', location.href.split('#')[0]);
 	  ga('send', 'pageview', { "title": document.title });
@@ -108,6 +109,8 @@ $('#right-menu').sidr({
 $('ul.nav').off().on('click', function(){
  $.sidr('close', 'nav');
 });
+
+<%= "#{AppSettings['design.footer_js']}".html_safe %>
 </script>
 
 

--- a/app/themes/light/views/layouts/light.html.erb
+++ b/app/themes/light/views/layouts/light.html.erb
@@ -109,9 +109,8 @@ $('#right-menu').sidr({
 $('ul.nav').off().on('click', function(){
  $.sidr('close', 'nav');
 });
-
-<%= "#{AppSettings['design.footer_js']}".html_safe %>
 </script>
+<%= "#{AppSettings['design.footer_js']}".html_safe %>
 
 
 </body>

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -109,7 +109,7 @@
             <%= f.text_field 'css.still_need_help', value: AppSettings['css.still_need_help'], label: t('still_need_help', default: "Still Need Help Background"), class: 'pick-a-color' %>
           <% end %>
           <%= f.text_area 'design.css', value: AppSettings['design.css'], label: "Custom CSS Styles", rows: 10, class: 'css-editor' %>
-          <%= f.text_area 'design.head_js', value: AppSettings['design.head_js'], label: "Head Javascript", rows: 10, class: 'css-editor' %>
+          <%= f.text_area 'design.header_js', value: AppSettings['design.header_js'], label: "Head Javascript", rows: 10, class: 'css-editor' %>
           <%= f.text_area 'design.footer_js', value: AppSettings['design.footer_js'], label: "Footer Javascript", rows: 10, class: 'css-editor' %>
       </div>
       <div class="settings-section theme hidden">

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -67,8 +67,8 @@
         <%= f.text_field 'settings.parent_company', value: AppSettings['settings.parent_company'], label: t('parent_company', default: "Parent Company") %>
         <%= f.text_field 'settings.site_tagline', value: AppSettings['settings.site_tagline'], label: t('site_tagline', default: "Site Tagline") %>
         <br/><br/>
-        <h4 class="settings-subsection">Helpy Functions</h4>
 
+        <h4 class="settings-subsection">Helpy Functions</h4>
         <%= f.check_box 'settings.forums', { checked: forums?, label: t('enable_forums', default: "Enable Community Forums"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
         <%= f.check_box 'settings.knowledgebase', { checked: knowledgebase?, label: t('enable_knowledgebase', default: "Enable Knowledgebase"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
         <%= f.check_box 'settings.tickets', { checked: tickets?, label: t('enable_tickets', default: "Enable Private Tickets"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
@@ -109,6 +109,8 @@
             <%= f.text_field 'css.still_need_help', value: AppSettings['css.still_need_help'], label: t('still_need_help', default: "Still Need Help Background"), class: 'pick-a-color' %>
           <% end %>
           <%= f.text_area 'design.css', value: AppSettings['design.css'], label: "Custom CSS Styles", rows: 10, class: 'css-editor' %>
+          <%= f.text_area 'design.head_js', value: AppSettings['design.head_js'], label: "Head Javascript", rows: 10, class: 'css-editor' %>
+          <%= f.text_area 'design.footer_js', value: AppSettings['design.footer_js'], label: "Footer Javascript", rows: 10, class: 'css-editor' %>
       </div>
       <div class="settings-section theme hidden">
         <div class="row">

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,12 +1,30 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "Cross Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "104064e677313b94825572a4d05d8531c24cdb3e90326cbf934925283754c18e",
+      "message": "Unescaped model attribute",
+      "file": "app/themes/helpy/views/layouts/helpy.html.erb",
+      "line": 9,
+      "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "AppSettings[\"design.header_js\"]",
+      "render_path": null,
+      "location": {
+        "type": "template",
+        "template": "layouts/helpy"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
       "warning_type": "File Access",
       "warning_code": 16,
       "fingerprint": "c6fb122f62bf327dfd3817ae58e788d2a30839d35d0ec7af830c981e5b302368",
       "message": "Model attribute used in file name",
       "file": "app/controllers/admin/settings_controller.rb",
-      "line": 13,
+      "line": 27,
       "link": "http://brakemanscanner.org/docs/warning_types/file_access/",
       "code": "send_file(File.join(Theme.find(params[:theme]).path, Theme.find(params[:theme]).thumbnail), :type => \"image/png\", :disposition => \"inline\", :stream => false)",
       "render_path": null,
@@ -22,13 +40,103 @@
     {
       "warning_type": "Cross Site Scripting",
       "warning_code": 2,
+      "fingerprint": "cc99fa0f83f3b063b2c416dca55ae681dbd2ff18f215107813227b791d0ef707",
+      "message": "Unescaped model attribute",
+      "file": "app/themes/light/views/layouts/light.html.erb",
+      "line": 8,
+      "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "AppSettings[\"design.header_js\"]",
+      "render_path": null,
+      "location": {
+        "type": "template",
+        "template": "layouts/light"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
+      "warning_type": "Cross Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "dcc33b3a2a7e4386162f09b793ab6cbc2c3a24337a1ed6b1df342480a1706315",
+      "message": "Unescaped model attribute",
+      "file": "app/themes/flat/views/layouts/flat.html.erb",
+      "line": 8,
+      "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "AppSettings[\"design.header_js\"]",
+      "render_path": null,
+      "location": {
+        "type": "template",
+        "template": "layouts/flat"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
+      "warning_type": "Cross Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "e17030e70ed23dfd5f7aae7eaad4247c400cc77f8b7635a1d7c66a743c84284e",
+      "message": "Unescaped model attribute",
+      "file": "app/themes/flat/views/layouts/flat.html.erb",
+      "line": 113,
+      "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "AppSettings[\"design.footer_js\"]",
+      "render_path": null,
+      "location": {
+        "type": "template",
+        "template": "layouts/flat"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
+      "warning_type": "Cross Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "e3b5a60880951a03eda817f8169cb1ef6d0ba091c755c486064671df26412d57",
+      "message": "Unescaped model attribute",
+      "file": "app/themes/helpy/views/layouts/helpy.html.erb",
+      "line": 67,
+      "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "AppSettings[\"design.footer_js\"]",
+      "render_path": null,
+      "location": {
+        "type": "template",
+        "template": "layouts/helpy"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
+      "warning_type": "Cross Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "eaaba6314a917f1c96a0d6d87868f542d3007e52e5d96ea288965d92ff1232c0",
+      "message": "Unescaped model attribute",
+      "file": "app/themes/light/views/layouts/light.html.erb",
+      "line": 113,
+      "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "AppSettings[\"design.footer_js\"]",
+      "render_path": null,
+      "location": {
+        "type": "template",
+        "template": "layouts/light"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
+      "warning_type": "Cross Site Scripting",
+      "warning_code": 2,
       "fingerprint": "f062db0937943cec43ebc5abe9beb082487c5a91d2ac3de650a4b1cb62d2bdd1",
       "message": "Unescaped model attribute",
       "file": "app/views/docs/show.html.erb",
-      "line": 35,
+      "line": 51,
       "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "Doc.where(:id => params[:id]).active.first.content",
-      "render_path": [{"type":"controller","class":"DocsController","method":"show","line":36,"file":"app/controllers/docs_controller.rb"}],
+      "render_path": [{"type":"controller","class":"DocsController","method":"show","line":37,"file":"app/controllers/docs_controller.rb"}],
       "location": {
         "type": "template",
         "template": "docs/show"
@@ -38,6 +146,6 @@
       "note": "Doc.content should only ever be entered by an admin, significantly mitigating the exposure."
     }
   ],
-  "updated": "2016-06-08 16:02:11 -0600",
+  "updated": "2016-10-23 10:17:06 -0600",
   "brakeman_version": "3.2.1"
 }

--- a/config/initializers/default_settings.rb
+++ b/config/initializers/default_settings.rb
@@ -23,6 +23,8 @@ AppSettings.defaults["design.header_logo"] = Settings.app_mini_logo
 # Note: the contributer accidentally reversed these in the code
 AppSettings.defaults["design.footer_mini_logo"] = Settings.app_large_logo
 AppSettings.defaults["design.css"] = ""
+AppSettings.defaults["design.header_js"] = ""
+AppSettings.defaults["design.footer_js"] = ""
 AppSettings.defaults["css.search_background"] = "feffe9"
 AppSettings.defaults["css.top_bar"] = "3cceff"
 AppSettings.defaults["css.link_color"] = "004084"


### PR DESCRIPTION
This adds a settings config for two javascript snippets- one in the `head` and one at the bottom of the `body`.  This will allow easy addition of analytics, chat or other scripts, including customization through jquery statements.