### PR TITLE
Pass id instead of full object to delayed mailers

### DIFF
--- a/app/controllers/admin/topics_controller.rb
+++ b/app/controllers/admin/topics_controller.rb
@@ -126,7 +126,7 @@ class Admin::TopicsController < Admin::BaseController
           :screenshots => params[:topic][:screenshots])
 
         # Send email
-        UserMailer.new_user(@user, @token).deliver_later
+        UserMailer.new_user(@user.id, @token).deliver_later
 
         # track event in GA
         tracker('Request', 'Post', 'New Topic')

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -158,7 +158,7 @@ class TopicsController < ApplicationController
         :screenshots => params[:topic][:screenshots])
 
       if built_user == true && !user_signed_in?
-        UserMailer.new_user(@user, @token).deliver_later
+        UserMailer.new_user(@user.id, @token).deliver_later
       end
 
       # track event in GA

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,47 +1,47 @@
 class NotificationMailer < ActionMailer::Base
 
-  def new_private(topic)
-    notifiable = User.notifiable_on_private
-    return if notifiable.count == 0
+  def new_private(topic_id)
+    notifiable_users = User.notifiable_on_private
+    return if notifiable_users.count == 0
 
-    @topic = topic
-    @recipient = notifiable.first
-    @bcc = notifiable.last(notifiable.count-1)
+    @topic = Topic.find(topic_id)
+    @recipient = notifiable_users.first
+    @bcc = notifiable_users.last(notifiable_users.count-1)
     mail(
       to: @recipient,
       bcc: @bcc,
       from: AppSettings['email.admin_email'],
-      subject: "[#{AppSettings['settings.site_name']}] ##{topic.id}-#{topic.name}"
+      subject: "[#{AppSettings['settings.site_name']}] ##{@topic.id}-#{@topic.name}"
       )
   end
 
-  def new_public(topic)
-    notifiable = User.notifiable_on_public
-    return if notifiable.count == 0
+  def new_public(topic_id)
+    notifiable_users = User.notifiable_on_public
+    return if notifiable_users.count == 0
 
-    @topic = topic
-    @recipient = notifiable.first
-    @bcc = notifiable.last(notifiable.count-1)
+    @topic = Topic.find(topic_id)
+    @recipient = notifiable_users.first
+    @bcc = notifiable_users.last(notifiable_users.count-1)
     mail(
       to: @recipient,
       bcc: @bcc,
       from: AppSettings['email.admin_email'],
-      subject: "[#{AppSettings['settings.site_name']}] ##{topic.id}-#{topic.name}"
+      subject: "[#{AppSettings['settings.site_name']}] ##{@topic.id}-#{@topic.name}"
       )
   end
 
-  def new_reply(topic)
-    notifiable = User.notifiable_on_reply
-    return if notifiable.count == 0
+  def new_reply(topic_id)
+    notifiable_users = User.notifiable_on_reply
+    return if notifiable_users.count == 0
 
-    @topic = topic
-    @recipient = notifiable.first
-    @bcc = notifiable.last(notifiable.count-1)
+    @topic = Topic.find(topic_id)
+    @recipient = notifiable_users.first
+    @bcc = notifiable_users.last(notifiable_users.count-1)
     mail(
       to: @recipient,
       bcc: @bcc,
       from: AppSettings['email.admin_email'],
-      subject: "[#{AppSettings['settings.site_name']}] ##{topic.id}-#{topic.name}"
+      subject: "[#{AppSettings['settings.site_name']}] ##{@topic.id}-#{@topic.name}"
       )
   end
 

--- a/app/mailers/topic_mailer.rb
+++ b/app/mailers/topic_mailer.rb
@@ -1,13 +1,13 @@
 class TopicMailer < ActionMailer::Base
   add_template_helper(ApplicationHelper)
 
-  def new_ticket(topic)
-    @topic = topic
-    email_with_name = %("#{topic.user.name}" <#{topic.user.email}>)
+  def new_ticket(topic_id)
+    @topic = Topic.find(topic_id)
+    email_with_name = %("#{@topic.user.name}" <#{@topic.user.email}>)
     mail(
       to: email_with_name,
       from: %("#{AppSettings['settings.site_name']}" <#{AppSettings['email.admin_email']}>),
-      subject: "[#{AppSettings['settings.site_name']}] ##{topic.id}-#{topic.name}"
+      subject: "[#{AppSettings['settings.site_name']}] ##{@topic.id}-#{@topic.name}"
       )
   end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,12 +1,12 @@
 class UserMailer < ActionMailer::Base
   add_template_helper(ApplicationHelper)
 
-  def new_user(user, token)
+  def new_user(user_id, token)
     return unless (AppSettings['settings.welcome_email'] == "1" || AppSettings['settings.welcome_email'] == true)
-    @user = user
+    @user = User.find(user_id)
     @token = token
     @locale = I18n.locale.to_s
-    email_with_name = %("#{user.name}" <#{user.email}>)
+    email_with_name = %("#{@user.name}" <#{@user.email}>)
     mail(
       to: email_with_name,
       from: %("#{AppSettings['settings.site_name']}" <#{AppSettings['email.admin_email']}>),

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -87,20 +87,20 @@ class Post < ActiveRecord::Base
   def notify
     # Handle new private ticket notification:
     if self.kind == "first" && self.topic.private?
-      NotificationMailer.new_private(self.topic).deliver_later
+      NotificationMailer.new_private(self.topic_id).deliver_later
     # Handles new public ticket notification:
     elsif self.kind == "first" && self.topic.public?
-      NotificationMailer.new_public(self.topic).deliver_later
+      NotificationMailer.new_public(self.topic_id).deliver_later
 
     # Handles customer reply notification:
     elsif self.kind == "reply" && self.user_id == self.topic.user_id && self.topic.private?
-      NotificationMailer.new_reply(self.topic).deliver_later
+      NotificationMailer.new_reply(self.topic_id).deliver_later
 
     # Reply from user back to the system
     elsif self.kind == "reply" && self.user_id != self.topic.user_id && self.topic.private?
       I18n.with_locale(self.email_locale) do
         # NOTE New ticket is misnamed, it should be new-reply
-        TopicMailer.new_ticket(self.topic).deliver_later
+        TopicMailer.new_ticket(self.topic_id).deliver_later
       end
     end
   end

--- a/lib/email_processor.rb
+++ b/lib/email_processor.rb
@@ -106,7 +106,7 @@ class EmailProcessor
     @user.name = @email.from[:name].blank? ? @email.from[:token] : @email.from[:name]
     @user.password = User.create_password
     if @user.save
-      UserMailer.new_user(@user, @token).deliver_later
+      UserMailer.new_user(@user.id, @token).deliver_later
     end
   end
 end

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -9,7 +9,7 @@ class NotificationMailerTest < ActionMailer::TestCase
       a.settings.notify_on_private = "0"
     end
 
-    notification = NotificationMailer.new_private(Topic.last)
+    notification = NotificationMailer.new_private(Topic.last.id)
 
     assert_emails 0 do
       notification.deliver_now
@@ -21,7 +21,7 @@ class NotificationMailerTest < ActionMailer::TestCase
       a.settings.notify_on_private = "1"
     end
 
-    notification = NotificationMailer.new_private(Topic.last)
+    notification = NotificationMailer.new_private(Topic.last.id)
 
     assert_emails 1 do
       notification.deliver_now
@@ -36,7 +36,7 @@ class NotificationMailerTest < ActionMailer::TestCase
       a.settings.notify_on_public = "0"
     end
 
-    notification = NotificationMailer.new_public(Topic.last)
+    notification = NotificationMailer.new_public(Topic.last.id)
     assert_emails 0 do
       notification.deliver_now
     end
@@ -47,7 +47,7 @@ class NotificationMailerTest < ActionMailer::TestCase
       a.settings.notify_on_public = "1"
     end
 
-    notification = NotificationMailer.new_public(Topic.last)
+    notification = NotificationMailer.new_public(Topic.last.id)
 
     assert_emails 1 do
       notification.deliver_now
@@ -62,7 +62,7 @@ class NotificationMailerTest < ActionMailer::TestCase
       a.settings.notify_on_reply = "0"
     end
 
-    notification = NotificationMailer.new_reply(Topic.last)
+    notification = NotificationMailer.new_reply(Topic.last.id)
     assert_emails 0 do
       notification.deliver_now
     end
@@ -73,7 +73,7 @@ class NotificationMailerTest < ActionMailer::TestCase
       a.settings.notify_on_reply = "1"
     end
 
-    notification = NotificationMailer.new_reply(Topic.last)
+    notification = NotificationMailer.new_reply(Topic.last.id)
 
     assert_emails 1 do
       notification.deliver_now
@@ -90,7 +90,7 @@ class NotificationMailerTest < ActionMailer::TestCase
       a.settings.notify_on_public = "1"
     end
 
-    notification = NotificationMailer.new_public(Topic.last)
+    notification = NotificationMailer.new_public(Topic.last.id)
 
     assert_emails 1 do
       notification.deliver_now
@@ -105,7 +105,7 @@ class NotificationMailerTest < ActionMailer::TestCase
       a.settings.notify_on_reply = "1"
     end
 
-    notification = NotificationMailer.new_reply(Topic.last)
+    notification = NotificationMailer.new_reply(Topic.last.id)
 
     assert_emails 1 do
       notification.deliver_now
@@ -123,7 +123,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     end
     User.agents.first.settings.notify_on_private = "1"
 
-    notification = NotificationMailer.new_private(Topic.last)
+    notification = NotificationMailer.new_private(Topic.last.id)
 
     assert_emails 1 do
       notification.deliver_now
@@ -139,7 +139,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     end
     User.agents.first.settings.notify_on_public = "1"
 
-    notification = NotificationMailer.new_public(Topic.last)
+    notification = NotificationMailer.new_public(Topic.last.id)
 
     assert_emails 1 do
       notification.deliver_now
@@ -155,7 +155,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     end
     User.agents.first.settings.notify_on_reply = "1"
 
-    notification = NotificationMailer.new_reply(Topic.last)
+    notification = NotificationMailer.new_reply(Topic.last.id)
 
     assert_emails 1 do
       notification.deliver_now

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -9,7 +9,7 @@ class TopicMailerTest < ActionMailer::TestCase
   test 'No mail sent if setting disabled' do
     AppSettings['settings.welcome_email'] = false
     user = users(:user)
-    email = UserMailer.new_user(user, 'token')
+    email = UserMailer.new_user(user.id, 'token')
 
     assert_emails 0 do
       email.deliver_now


### PR DESCRIPTION
This is for thread safety with job servers.