### PR TITLE
Refactor notifications storage

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -15,10 +15,11 @@ class Admin::SettingsController < Admin::BaseController
 
   # Save notification preference for current agent/admin
   def update_notifications
-    current_user.settings.notify_on_private = params['notify_on_private']
-    current_user.settings.notify_on_public = params['notify_on_public']
-    current_user.settings.notify_on_reply = params['notify_on_reply']
-
+    user = current_user
+    user.notify_on_private = params[:notify_on_private]
+    user.notify_on_public = params[:notify_on_public]
+    user.notify_on_reply = params[:notify_on_reply]
+    user.save!
     redirect_to admin_settings_path
   end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -123,7 +123,10 @@ class Admin::UsersController < Admin::BaseController
       :linkedin,
       :language,
       :team_list,
-      :active
+      :active,
+      :notify_on_private,
+      :notify_on_public,
+      :notify_on_reply
     )
   end
 

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -6,9 +6,9 @@ class NotificationMailer < ActionMailer::Base
 
     @topic = Topic.find(topic_id)
     @recipient = notifiable_users.first
-    @bcc = notifiable_users.last(notifiable_users.count-1)
+    @bcc = notifiable_users.last(notifiable_users.count-1).collect {|u| u.email}
     mail(
-      to: @recipient,
+      to: @recipient.email,
       bcc: @bcc,
       from: AppSettings['email.admin_email'],
       subject: "[#{AppSettings['settings.site_name']}] ##{@topic.id}-#{@topic.name}"
@@ -21,9 +21,9 @@ class NotificationMailer < ActionMailer::Base
 
     @topic = Topic.find(topic_id)
     @recipient = notifiable_users.first
-    @bcc = notifiable_users.last(notifiable_users.count-1)
+    @bcc = notifiable_users.last(notifiable_users.count-1).collect {|u| u.email}
     mail(
-      to: @recipient,
+      to: @recipient.email,
       bcc: @bcc,
       from: AppSettings['email.admin_email'],
       subject: "[#{AppSettings['settings.site_name']}] ##{@topic.id}-#{@topic.name}"
@@ -36,9 +36,9 @@ class NotificationMailer < ActionMailer::Base
 
     @topic = Topic.find(topic_id)
     @recipient = notifiable_users.first
-    @bcc = notifiable_users.last(notifiable_users.count-1)
+    @bcc = notifiable_users.last(notifiable_users.count-1).collect {|u| u.email}
     mail(
-      to: @recipient,
+      to: @recipient.email,
       bcc: @bcc,
       from: AppSettings['email.admin_email'],
       subject: "[#{AppSettings['settings.site_name']}] ##{@topic.id}-#{@topic.name}"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -120,15 +120,15 @@ class User < ActiveRecord::Base
   end
 
   def self.notifiable_on_public
-    User.agents.where(notify_on_public: true).order('id asc')
+    User.agents.where(notify_on_public: true).reorder('id asc')
   end
 
   def self.notifiable_on_private
-    User.agents.where(notify_on_private: true).order('id asc')
+    User.agents.where(notify_on_private: true).reorder('id asc')
   end
 
   def self.notifiable_on_reply
-    User.agents.where(notify_on_reply: true).order('id asc')
+    User.agents.where(notify_on_reply: true).reorder('id asc')
   end
 
   def active_assigned_count

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -93,7 +93,7 @@ class User < ActiveRecord::Base
   is_gravtastic
 
   after_invitation_accepted :set_role_on_invitation_accept
-  after_create :enable_notifications_for_agents
+  after_create :enable_notifications_for_admin
   acts_as_taggable_on :teams
 
   ROLES = %w[admin agent editor user]
@@ -111,31 +111,30 @@ class User < ActiveRecord::Base
     self.save
   end
 
-  def enable_notifications_for_agents
-    if self.role == "agent" || self.role == "admin"
+  def enable_notifications_for_admin
+    if self.role == "admin"
       self.settings.notify_on_private = "1"
       self.settings.notify_on_public = "1"
       self.settings.notify_on_reply = "1"
-    else
-      self.settings.notify_on_private = nil
-      self.settings.notify_on_public = nil
-      self.settings.notify_on_reply = nil
     end
   end
 
   def self.notifiable_on_public
     # Iterates through agents, selecting those with notifications on
-    User.agents.order('id asc').map { |a| a.settings.notify_on_public == "1" ? a.email : '' }.select {|x| x.present?}
+    # User.agents.order('id asc').map { |a| a.settings.notify_on_public == "1" ? a.email : '' }.select {|x| x.present?}
+    User.agents.where(notify_on_public: true).order('id asc')
   end
 
   def self.notifiable_on_private
     # Iterates through agents, selecting those with notifications on
-    User.agents.order('id asc').map { |a| a.settings.notify_on_private == "1" ? a.email : '' }.select {|x| x.present?}
+    # User.agents.order('id asc').map { |a| a.settings.notify_on_private == "1" ? a.email : '' }.select {|x| x.present?}
+    User.agents.where(notify_on_private: true).order('id asc')
   end
 
   def self.notifiable_on_reply
     # Iterates through agents, selecting those with notifications on
-    User.agents.order('id asc').map { |a| a.settings.notify_on_reply == "1" ? a.email : '' }.select {|x| x.present?}
+    # User.agents.order('id asc').map { |a| a.settings.notify_on_reply == "1" ? a.email : '' }.select {|x| x.present?}
+    User.agents.where(notify_on_reply: true).order('id asc')
   end
 
   def active_assigned_count

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -113,27 +113,21 @@ class User < ActiveRecord::Base
 
   def enable_notifications_for_admin
     if self.role == "admin"
-      self.settings.notify_on_private = "1"
-      self.settings.notify_on_public = "1"
-      self.settings.notify_on_reply = "1"
+      self.notify_on_private = true
+      self.notify_on_public = true
+      self.notify_on_reply = true
     end
   end
 
   def self.notifiable_on_public
-    # Iterates through agents, selecting those with notifications on
-    # User.agents.order('id asc').map { |a| a.settings.notify_on_public == "1" ? a.email : '' }.select {|x| x.present?}
     User.agents.where(notify_on_public: true).order('id asc')
   end
 
   def self.notifiable_on_private
-    # Iterates through agents, selecting those with notifications on
-    # User.agents.order('id asc').map { |a| a.settings.notify_on_private == "1" ? a.email : '' }.select {|x| x.present?}
     User.agents.where(notify_on_private: true).order('id asc')
   end
 
   def self.notifiable_on_reply
-    # Iterates through agents, selecting those with notifications on
-    # User.agents.order('id asc').map { |a| a.settings.notify_on_reply == "1" ? a.email : '' }.select {|x| x.present?}
     User.agents.where(notify_on_reply: true).order('id asc')
   end
 

--- a/app/views/admin/settings/notifications.html.erb
+++ b/app/views/admin/settings/notifications.html.erb
@@ -9,9 +9,9 @@
   <div class="col-md-9 col-sm-8 col-xs-10">
     <%= bootstrap_form_tag url: admin_update_notifications_path, method: 'put', remote: false do |f| %>
       <div class="settings-section notifications" data-hook="admin_settings_notifications">
-        <%= f.check_box 'notify_on_private', { checked: current_user.settings.notify_on_private == "1", label: t('notify_on_private', default: "Email me when a private customer question has been received"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
-        <%= f.check_box 'notify_on_public', { checked: current_user.settings.notify_on_public == "1", label: t('notify_on_public', default: "Email me when a public customer question has been posted"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
-        <%= f.check_box 'notify_on_reply', { checked: current_user.settings.notify_on_reply == "1", label: t('notify_on_reply', default: "Email me when a new reply to a private discussion has been received"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
+        <%= f.check_box 'notify_on_private', { checked: current_user.notify_on_private?, label: t('notify_on_private', default: "Email me when a private customer question has been received"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
+        <%= f.check_box 'notify_on_public', { checked: current_user.notify_on_public?, label: t('notify_on_public', default: "Email me when a public customer question has been posted"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
+        <%= f.check_box 'notify_on_reply', { checked: current_user.notify_on_reply?, label: t('notify_on_reply', default: "Email me when a new reply to a private discussion has been received"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
       </div>
       <div class="submit-section">
         <%= f.submit "Save Settings", class: 'btn btn-warning' %>

--- a/app/views/admin/settings/notifications.html.erb
+++ b/app/views/admin/settings/notifications.html.erb
@@ -2,7 +2,7 @@
 
 <div class="admin-header">
   <h2 id="setting-header">
-    Your Notifications
+    <%= t('notifications', default: 'Notifications') %>
   </h2>
 </div>
 <div class="settings-panel row">

--- a/app/views/admin/users/_edit.html.erb
+++ b/app/views/admin/users/_edit.html.erb
@@ -9,7 +9,7 @@
       <%= f.text_field :city, inline: true %> <%= f.text_field :state, inline: true  %>
       <%#= @topic.user.country.titleize unless @topic.user.country.nil? %>
       <%= f.select(:role, [['Select Role',''],['Admin','admin'],['Agent','agent'],['Editor','editor'],['User','user']]) if current_user.is_admin? %>
-      <%= f.text_field :team_list, value: @user.team_list.to_s, class: 'selectize form-control', label: "Group Membership" if AppSettings['settings.teams'] and current_user.is_admin? and @user.is_agent? %>
+      <%= f.text_field :team_list, value: @user.team_list.to_s, class: 'selectize form-control', label: "Group Membership" if AppSettings['settings.teams'] && current_user.is_admin? && @user.is_agent? %>
       <%= f.check_box :active %> <%#= f.check_box :admin, inline: true %>
     </div>
     <div class="user-section">
@@ -23,6 +23,14 @@
       <%= f.text_field :twitter %>
       <%= f.text_field :linkedin %>
     </div>
+    <% if current_user.is_admin? && @user.is_agent? %>
+    <div class="user-section">
+      <div class="tiny-header"><%= t(:notifications, default: "Notifications") %>:</div>
+      <%= f.check_box 'notify_on_private', { checked: @user.notify_on_private?, label: t('notify_on_private', default: "Email me when a private customer question has been received"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
+      <%= f.check_box 'notify_on_public', { checked: @user.notify_on_public?, label: t('notify_on_public', default: "Email me when a public customer question has been posted"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
+      <%= f.check_box 'notify_on_reply', { checked: @user.notify_on_reply?, label: t('notify_on_reply', default: "Email me when a new reply to a private discussion has been received"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
+    </div>
+    <% end %>
     <%= f.submit "Save", class: 'btn btn-warning' %>
   </div>
 <% end %>

--- a/db/migrate/20161027135234_add_notifications_to_user.rb
+++ b/db/migrate/20161027135234_add_notifications_to_user.rb
@@ -1,0 +1,12 @@
+class AddNotificationsToUser < ActiveRecord::Migration
+  def change
+    change_table :users do |t|
+      t.boolean   :notify_on_private, default: false
+      t.boolean   :notify_on_public, default: false
+      t.boolean   :notify_on_reply, default: false
+      t.index     :notify_on_private
+      t.index     :notify_on_public
+      t.index     :notify_on_reply
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161017170305) do
+ActiveRecord::Schema.define(version: 20161027135234) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -267,12 +267,18 @@ ActiveRecord::Schema.define(version: 20161017170305) do
     t.text     "invitation_message"
     t.string   "time_zone",              default: "UTC"
     t.string   "profile_image"
+    t.boolean  "notify_on_private",      default: false
+    t.boolean  "notify_on_public",       default: false
+    t.boolean  "notify_on_reply",        default: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["invitation_token"], name: "index_users_on_invitation_token", unique: true, using: :btree
   add_index "users", ["invitations_count"], name: "index_users_on_invitations_count", using: :btree
   add_index "users", ["invited_by_id"], name: "index_users_on_invited_by_id", using: :btree
+  add_index "users", ["notify_on_private"], name: "index_users_on_notify_on_private", using: :btree
+  add_index "users", ["notify_on_public"], name: "index_users_on_notify_on_public", using: :btree
+  add_index "users", ["notify_on_reply"], name: "index_users_on_notify_on_reply", using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
   create_table "versions", force: :cascade do |t|

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -52,13 +52,6 @@ namespace :db do
     puts "Created Agent: #{u.name}"
   end
 
-  # Disable notifications for our new agents
-  User.agents.each do |a|
-    a.settings.notify_on_reply = "0"
-    a.settings.notify_on_private = "0"
-    a.settings.notify_on_public = "0"
-  end
-
   # Create users with avatars
   number_users.times do
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -66,6 +66,9 @@ admin:
   admin: true
   role: admin
   encrypted_password: $2a$10$NDaQ2l6.7dqkWTbqZGX6RuokqiUrfrcouiKc3YCGKIvz9KxhPt7uK
+  notify_on_private: true
+  notify_on_public: true
+  notify_on_reply: true
 
 user:
   id: 2
@@ -105,6 +108,9 @@ another_admin:
   admin: false
   role: admin
   encrypted_password: $2a$10$NDaQ2l6.7dqkWTbqZGX6RuokqiUrfrcouiKc3YCGKIvz9KxhPt7uK
+  notify_on_private: true
+  notify_on_public: true
+  notify_on_reply: true
 
 agent:
   id: 6
@@ -115,6 +121,9 @@ agent:
   admin: false
   role: agent
   encrypted_password: $2a$10$NDaQ2l6.7dqkWTbqZGX6RuokqiUrfrcouiKc3YCGKIvz9KxhPt7uK
+  notify_on_private: true
+  notify_on_public: true
+  notify_on_reply: true
 
 editor:
   id: 7

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -2,13 +2,23 @@ require 'test_helper'
 
 class NotificationMailerTest < ActionMailer::TestCase
 
+  def setup
+    set_default_settings
+  end
+
+  def disable_all_notifications
+    User.agents.each do |a|
+      a.notify_on_private = false
+      a.notify_on_public = false
+      a.notify_on_reply = false
+      a.save!
+    end
+  end
+
   # This test makes sure no notification is sent if notifications are turned off
   # for everyone
   test 'Should not send if there are no agents with private notifications on' do
-    User.agents.each do |a|
-      a.settings.notify_on_private = "0"
-    end
-
+    disable_all_notifications
     notification = NotificationMailer.new_private(Topic.last.id)
 
     assert_emails 0 do
@@ -17,9 +27,10 @@ class NotificationMailerTest < ActionMailer::TestCase
   end
 
   test 'Should send one private message notification if there are agents with notifications on' do
-    User.agents.each do |a|
-      a.settings.notify_on_private = "1"
-    end
+    # User.agents.each do |a|
+    #   a.notify_on_private = true
+    #   a.save!
+    # end
 
     notification = NotificationMailer.new_private(Topic.last.id)
 
@@ -27,51 +38,48 @@ class NotificationMailerTest < ActionMailer::TestCase
       notification.deliver_now
     end
 
-    assert_equal notification.to[0], User.notifiable_on_private.first
-    assert_equal notification.bcc, User.notifiable_on_private.last(2)
+    assert_equal notification.to[0], User.notifiable_on_private.collect {|u| u.email}.first
+    assert_equal notification.bcc, User.notifiable_on_private.last(2).collect {|u| u.email}
   end
 
   test 'Should not send if there are no agents with public notifications on' do
-    User.agents.each do |a|
-      a.settings.notify_on_public = "0"
-    end
-
+    disable_all_notifications
     notification = NotificationMailer.new_public(Topic.last.id)
+
     assert_emails 0 do
       notification.deliver_now
     end
   end
 
   test 'Should send one notification if there are agents with public notifications on' do
-    User.agents.each do |a|
-      a.settings.notify_on_public = "1"
-    end
-
+    # User.agents.each do |a|
+    #   a.notify_on_public = true
+    #   a.save!
+    # end
     notification = NotificationMailer.new_public(Topic.last.id)
 
     assert_emails 1 do
       notification.deliver_now
     end
 
-    assert_equal notification.to[0], User.notifiable_on_public.first
-    assert_equal notification.bcc, User.notifiable_on_public.last(2)
+    assert_equal notification.to[0], User.notifiable_on_public.collect {|u| u.email}.first
+    assert_equal notification.bcc, User.notifiable_on_public.last(2).collect {|u| u.email}
   end
 
   test 'Should not send if there are no agents with reply notifications on' do
-    User.agents.each do |a|
-      a.settings.notify_on_reply = "0"
-    end
-
+    disable_all_notifications
     notification = NotificationMailer.new_reply(Topic.last.id)
+
     assert_emails 0 do
       notification.deliver_now
     end
   end
 
   test 'Should send one notification if there are agents with reply notifications on' do
-    User.agents.each do |a|
-      a.settings.notify_on_reply = "1"
-    end
+    # User.agents.each do |a|
+    #   a.notify_on_reply = true
+    #   a.save!
+    # end
 
     notification = NotificationMailer.new_reply(Topic.last.id)
 
@@ -79,65 +87,64 @@ class NotificationMailerTest < ActionMailer::TestCase
       notification.deliver_now
     end
 
-    assert_equal notification.to[0], User.notifiable_on_reply.first
-    assert_equal notification.bcc, User.notifiable_on_reply.last(2)
+    assert_equal notification.to[0], User.notifiable_on_reply.collect {|u| u.email}.first
+    assert_equal notification.bcc, User.notifiable_on_reply.last(2).collect {|u| u.email}
   end
 
   # These tests make sure that notifications are sent out to all agents with them
   # turned on.
   test 'Should send one public message notification if there are agents with notifications on' do
-    User.agents.each do |a|
-      a.settings.notify_on_public = "1"
-    end
-
+    # User.agents.each do |a|
+    #   a.notify_on_public = true
+    #   a.save!
+    # end
     notification = NotificationMailer.new_public(Topic.last.id)
 
     assert_emails 1 do
       notification.deliver_now
     end
 
-    assert_equal notification.to[0], User.notifiable_on_public.first
-    assert_equal notification.bcc, User.notifiable_on_public.last(2)
+    assert_equal notification.to[0], User.notifiable_on_public.collect {|u| u.email}.first
+    assert_equal notification.bcc, User.notifiable_on_public.last(2).collect {|u| u.email}
   end
 
   test 'Should send one reply message notification if there are agents with notifications on' do
-    User.agents.each do |a|
-      a.settings.notify_on_reply = "1"
-    end
-
+    # User.agents.each do |a|
+    #   a.notify_on_reply = true
+    #   a.save!
+    # end
     notification = NotificationMailer.new_reply(Topic.last.id)
 
     assert_emails 1 do
       notification.deliver_now
     end
 
-    assert_equal notification.to[0], User.notifiable_on_reply.first
-    assert_equal notification.bcc, User.notifiable_on_reply.last(2)
+    assert_equal notification.to[0], User.notifiable_on_reply.collect {|u| u.email}.first
+    assert_equal notification.bcc, User.notifiable_on_reply.last(2).collect {|u| u.email}
   end
 
 
   # These tests check to make sure it works if there is only one agent with a notification
   test 'Should send one private message notification if there is one agent with notifications on' do
-    User.agents.each do |a|
-      a.settings.notify_on_private = "0"
-    end
-    User.agents.first.settings.notify_on_private = "1"
+    disable_all_notifications
+    user = User.agents.first
+    user.notify_on_private = true
+    user.save!
 
     notification = NotificationMailer.new_private(Topic.last.id)
-
     assert_emails 1 do
       notification.deliver_now
     end
 
-    assert_equal notification.to[0], User.notifiable_on_private.first
+    assert_equal notification.to[0], User.notifiable_on_private.collect {|u| u.email}.first
     assert_equal notification.bcc, []
   end
 
   test 'Should send one public message notification if there is one agent with notifications on' do
-    User.agents.each do |a|
-      a.settings.notify_on_public = "0"
-    end
-    User.agents.first.settings.notify_on_public = "1"
+    disable_all_notifications
+    user = User.agents.first
+    user.notify_on_public = true
+    user.save!
 
     notification = NotificationMailer.new_public(Topic.last.id)
 
@@ -145,23 +152,22 @@ class NotificationMailerTest < ActionMailer::TestCase
       notification.deliver_now
     end
 
-    assert_equal notification.to[0], User.notifiable_on_public.first
+    assert_equal notification.to[0], User.notifiable_on_public.collect {|u| u.email}.first
     assert_equal notification.bcc, []
   end
 
   test 'Should send one reply message notification if there is one agent with notifications on' do
-    User.agents.each do |a|
-      a.settings.notify_on_reply = "0"
-    end
-    User.agents.first.settings.notify_on_reply = "1"
+    disable_all_notifications
+    user = User.agents.first
+    user.notify_on_reply = true
+    user.save!
 
     notification = NotificationMailer.new_reply(Topic.last.id)
 
     assert_emails 1 do
       notification.deliver_now
     end
-
-    assert_equal notification.to[0], User.notifiable_on_reply.first
+    assert_equal notification.to[0], User.notifiable_on_reply.collect {|u| u.email}.first
     assert_equal notification.bcc, []
   end
 

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -27,11 +27,6 @@ class NotificationMailerTest < ActionMailer::TestCase
   end
 
   test 'Should send one private message notification if there are agents with notifications on' do
-    # User.agents.each do |a|
-    #   a.notify_on_private = true
-    #   a.save!
-    # end
-
     notification = NotificationMailer.new_private(Topic.last.id)
 
     assert_emails 1 do
@@ -52,10 +47,6 @@ class NotificationMailerTest < ActionMailer::TestCase
   end
 
   test 'Should send one notification if there are agents with public notifications on' do
-    # User.agents.each do |a|
-    #   a.notify_on_public = true
-    #   a.save!
-    # end
     notification = NotificationMailer.new_public(Topic.last.id)
 
     assert_emails 1 do
@@ -76,11 +67,6 @@ class NotificationMailerTest < ActionMailer::TestCase
   end
 
   test 'Should send one notification if there are agents with reply notifications on' do
-    # User.agents.each do |a|
-    #   a.notify_on_reply = true
-    #   a.save!
-    # end
-
     notification = NotificationMailer.new_reply(Topic.last.id)
 
     assert_emails 1 do
@@ -94,10 +80,6 @@ class NotificationMailerTest < ActionMailer::TestCase
   # These tests make sure that notifications are sent out to all agents with them
   # turned on.
   test 'Should send one public message notification if there are agents with notifications on' do
-    # User.agents.each do |a|
-    #   a.notify_on_public = true
-    #   a.save!
-    # end
     notification = NotificationMailer.new_public(Topic.last.id)
 
     assert_emails 1 do
@@ -109,10 +91,6 @@ class NotificationMailerTest < ActionMailer::TestCase
   end
 
   test 'Should send one reply message notification if there are agents with notifications on' do
-    # User.agents.each do |a|
-    #   a.notify_on_reply = true
-    #   a.save!
-    # end
     notification = NotificationMailer.new_reply(Topic.last.id)
 
     assert_emails 1 do

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -30,9 +30,9 @@ class PostTest < ActiveSupport::TestCase
 
     # assign all agents to receive notifications
     User.agents.each do |a|
-      a.settings.notify_on_private = "1"
-      a.settings.notify_on_public = "1"
-      a.settings.notify_on_reply = "1"
+      a.notify_on_private = true
+      a.notify_on_public = true
+      a.notify_on_reply = true
     end
 
   end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -26,18 +26,6 @@ class PostTest < ActiveSupport::TestCase
   should validate_presence_of(:kind)
   should validate_length_of(:body).is_at_most(10_000)
 
-  setup do
-
-    # assign all agents to receive notifications
-    User.agents.each do |a|
-      a.notify_on_private = true
-      a.notify_on_public = true
-      a.notify_on_reply = true
-    end
-
-  end
-
-
   # first post should be kind first
   # post belonging to a topic with multiple posts should be a reply
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -205,9 +205,9 @@ class UserTest < ActiveSupport::TestCase
       password: '12345678',
       role: 'agent'
     )
-    assert_equal u.settings.notify_on_private, "1"
-    assert_equal u.settings.notify_on_public, "1"
-    assert_equal u.settings.notify_on_reply, "1"
+    assert_equal u.notify_on_private, false
+    assert_equal u.notify_on_public, false
+    assert_equal u.notify_on_reply, false
   end
 
   test "An admin should be enabled for notifications after they are created" do
@@ -217,9 +217,9 @@ class UserTest < ActiveSupport::TestCase
       password: '12345678',
       role: 'admin'
     )
-    assert_equal u.settings.notify_on_private, "1"
-    assert_equal u.settings.notify_on_public, "1"
-    assert_equal u.settings.notify_on_reply, "1"
+    assert_equal u.notify_on_private, true
+    assert_equal u.notify_on_public, true
+    assert_equal u.notify_on_reply, true
   end
 
   test "A user should NOT be enabled for notifications after they are created" do
@@ -229,9 +229,9 @@ class UserTest < ActiveSupport::TestCase
       password: '12345678',
       role: 'user'
     )
-    assert_equal nil, u.settings.notify_on_private, "Should not be enabled for private notifications"
-    assert_equal nil, u.settings.notify_on_public, "Should not be enabled for public notifications"
-    assert_equal nil, u.settings.notify_on_reply, "Should not be enabled for reply notifications"
+    assert_equal u.notify_on_private, false, "Should not be enabled for private notifications"
+    assert_equal u.notify_on_public, false, "Should not be enabled for public notifications"
+    assert_equal u.notify_on_reply, false, "Should not be enabled for reply notifications"
   end
 
   test "Should be able to assign an agent to a group" do
@@ -247,35 +247,29 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "notifiable_on_private should return private scope" do
-    User.agents.each do |a|
-      a.notify_on_private = true
-      a.save!
-    end
 
     assert_equal 3, User.notifiable_on_private.count, "Should return the number of notifiable users"
-    User.agents.last.notify_on_private = false
+    u = User.agents.last
+    u.notify_on_private = false
+    u.save!
+
     assert_equal 2, User.notifiable_on_private.count, "Should return one less notifiable users"
   end
 
   test "notifiable_on_public should return public scope" do
-    User.agents.each do |a|
-      a.notify_on_public = true
-      a.save!
-    end
 
     assert_equal 3, User.notifiable_on_public.count, "Should return the number of notifiable users"
-    User.agents.last.notify_on_public = false
+    u = User.agents.last
+    u.notify_on_public = false
+    u.save!
     assert_equal 2, User.notifiable_on_public.count, "Should return one less notifiable users"
   end
 
   test "notifiable_on_reply should return reply scope" do
-    User.agents.each do |a|
-      a.notify_on_reply = true
-      a.save!
-    end
-
     assert_equal 3, User.notifiable_on_reply.count, "Should return the number of notifiable users"
-    User.agents.last.notify_on_reply = false
+    u = User.agents.last
+    u.notify_on_reply = false
+    u.save!
     assert_equal 2, User.notifiable_on_reply.count, "Should return one less notifiable users"
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -248,31 +248,34 @@ class UserTest < ActiveSupport::TestCase
 
   test "notifiable_on_private should return private scope" do
     User.agents.each do |a|
-      a.settings.notify_on_private = "1"
+      a.notify_on_private = true
+      a.save!
     end
 
     assert_equal 3, User.notifiable_on_private.count, "Should return the number of notifiable users"
-    User.agents.last.settings.notify_on_private = "0"
+    User.agents.last.notify_on_private = false
     assert_equal 2, User.notifiable_on_private.count, "Should return one less notifiable users"
   end
 
   test "notifiable_on_public should return public scope" do
     User.agents.each do |a|
-      a.settings.notify_on_public = "1"
+      a.notify_on_public = true
+      a.save!
     end
 
     assert_equal 3, User.notifiable_on_public.count, "Should return the number of notifiable users"
-    User.agents.last.settings.notify_on_public = "0"
+    User.agents.last.notify_on_public = false
     assert_equal 2, User.notifiable_on_public.count, "Should return one less notifiable users"
   end
 
   test "notifiable_on_reply should return reply scope" do
     User.agents.each do |a|
-      a.settings.notify_on_reply = "1"
+      a.notify_on_reply = true
+      a.save!
     end
 
     assert_equal 3, User.notifiable_on_reply.count, "Should return the number of notifiable users"
-    User.agents.last.settings.notify_on_reply = "0"
+    User.agents.last.notify_on_reply = false
     assert_equal 2, User.notifiable_on_reply.count, "Should return one less notifiable users"
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -88,9 +88,10 @@ def set_default_settings
 
   # assign all agents to receive notifications
   User.agents.each do |a|
-    a.settings.notify_on_private = "1"
-    a.settings.notify_on_public = "1"
-    a.settings.notify_on_reply = "1"
+    a.notify_on_private = true
+    a.notify_on_public = true
+    a.notify_on_reply = true
+    a.save!
   end
 
 end


### PR DESCRIPTION
Stores the notifications on the User model instead of using cached settings gem which caused problems, especially with Sidekiq
