### PR TITLE
Prevent error if no Cloudinary config found

### DIFF
--- a/app/views/posts/_thumbnail.html.erb
+++ b/app/views/posts/_thumbnail.html.erb
@@ -12,11 +12,11 @@
     <%= content_tag(:ul, class: 'list-inline') do %>
         <%- model_name.screenshots.each do |screenshot| %>
           <%= content_tag(:li, class: screenshot.resource_type) do %>
-            <% if screenshot.resource_type == "raw" %>
+            <% if Cloudinary.config.cloud_name.present? && screenshot.resource_type == "raw" %>
                 <%= link_to "https://res.cloudinary.com/#{Cloudinary.config.cloud_name}/raw/upload/#{screenshot.path}", title: screenshot.path, target: 'blank' do %>
                   <%= content_tag(:i, '', class: attachment_icon(screenshot.path)) %>
                 <% end %>
-            <% else %>
+            <% elsif Cloudinary.config.cloud_name.present? %>
               <%= link_to cl_image_tag(get_path(screenshot), { size: '125x125', crop: :fit }), "https://res.cloudinary.com/#{Cloudinary.config.cloud_name}/image/upload/#{screenshot.path}", class: 'screenshot-link', target: 'blank' %>
             <% end %>
           <% end %>


### PR DESCRIPTION
Only shows Cloudinary attachments if cloud_name is available to create URLs