### PR TITLE
Update VERSION to 1.0.5

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -5,6 +5,6 @@ require File.expand_path('../application', __FILE__)
 Rails.application.initialize!
 
 # Get the current tag version
-VERSION = '1.0.0'
+VERSION = '1.0.5'
 REVISION = `git log --pretty=format:'%h' -n 1`
 APP_VERSION = "#{VERSION}:#{REVISION}"


### PR DESCRIPTION
The `1.0.5` release did not update the version displayed in the app footer.