### PR TITLE
Fix deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rails', '4.2.7.1'
 gem 'pg'
 gem 'pg_search'
 # Use SCSS for stylesheets
-gem 'sass-rails', '~> 5.0'
+gem 'sass-rails', '~> 5.0.6'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -476,8 +476,8 @@ GEM
     rubyzip (1.2.0)
     safe_yaml (1.0.4)
     sass (3.4.22)
-    sass-rails (5.0.4)
-      railties (>= 4.0.0, < 5.0)
+    sass-rails (5.0.6)
+      railties (>= 4.0.0, < 6)
       sass (~> 3.1)
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
@@ -677,7 +677,7 @@ DEPENDENCIES
   recaptcha
   route_translator
   rubocop
-  sass-rails (~> 5.0)
+  sass-rails (~> 5.0.6)
   scss-lint
   sdoc (~> 0.4.0)
   selectize-rails

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -103,8 +103,7 @@ class Post < ActiveRecord::Base
     # Reply from user back to the system
     elsif self.kind == "reply" && self.user_id != self.topic.user_id && self.topic.private?
       I18n.with_locale(self.email_locale) do
-        # NOTE New ticket is misnamed, it should be new-reply
-        PostMailer.new_post(self).deliver_later
+        PostMailer.new_post(id).deliver_later
       end
     end
   end


### PR DESCRIPTION
Fixes some deprecation warnings.

The `saas-rails` version is bumped as `< 5.0.6` throws:

```
DEPRECATION WARNING: Sprockets method `register_engine` is deprecated.
Please register a mime type using `register_mime_type` then
use `register_compressor` or `register_transformer`.
```

Also #436 led to the following being throw:

```
DEPRECATION WARNING: You are passing an instance of ActiveRecord::Base to `find`.
 Please pass the id of the object by calling `.id`. 
(called from new_post at /Users/christiangregg/dev/helpy/app/mailers/post_mailer.rb:5)
```