### PR TITLE
Use the cached `user_name` instead of `user.name`

### DIFF
--- a/app/mailers/post_mailer.rb
+++ b/app/mailers/post_mailer.rb
@@ -4,7 +4,7 @@ class PostMailer < ActionMailer::Base
   def new_post(post_id)
     @post = Post.find(post_id)
     @topic = @post.topic
-    email_with_name = %("#{@topic.user.name}" <#{@topic.user.email}>)
+    email_with_name = %("#{@topic.user_name}" <#{@topic.user.email}>)
     @post.attachments.each do |att|
       attachments[att.file.filename] = File.read(att.file.file)
     end

--- a/app/mailers/topic_mailer.rb
+++ b/app/mailers/topic_mailer.rb
@@ -4,7 +4,7 @@ class TopicMailer < ActionMailer::Base
   def new_ticket(topic_id)
     @topic = Topic.find(topic_id)
     @post = @topic.posts.last
-    email_with_name = %("#{@topic.user.name}" <#{@topic.user.email}>)
+    email_with_name = %("#{@topic.user_name}" <#{@topic.user.email}>)
     @topic.posts.last.attachments.each do |att|
       attachments[att.file.filename] = File.read(att.file.file)
     end

--- a/app/views/admin/topics/_topic.html.erb
+++ b/app/views/admin/topics/_topic.html.erb
@@ -14,7 +14,7 @@
         <% tag_listing(topic.team_list) %>
       </span>
     <span class="less-important user-link">
-      <%= link_to t(:started_by, username: topic.user.name? ? topic.user.name.titleize : topic.user.email, default: "Started by #{topic.user.name? ? topic.user.name.titleize : topic.user.email}"), admin_user_path(topic.user.id), remote: true %>
+      <%= link_to t(:started_by, username: topic.user_name? ? topic.user_name.titleize : topic.user.email, default: "Started by #{topic.user_name? ? topic.user_name.titleize : topic.user.email}"), admin_user_path(topic.user.id), remote: true %>
       - <%= assigned_to(topic) %>
     </span>
   </td>

--- a/app/views/admin/users/_user_info.html.erb
+++ b/app/views/admin/users/_user_info.html.erb
@@ -6,7 +6,7 @@
 <div class="row">
   <div class='col-md-12' id='user-info-info'>
     <div id="user-contact-info" class="user-info">
-      <div class="tiny-header"><%= @topic.user.name? ? @topic.user.name.titleize : @topic.user.email %></div>
+      <div class="tiny-header"><%= @topic.user_name? ? @topic.user_name.titleize : @topic.user.email %></div>
       <span class="small">
         <%= @topic.user.company.titleize unless @topic.user.company.nil? %><br/>
         <%= @topic.user.city.titleize + ', ' unless @topic.user.city.nil? %> <%= @topic.user.state.titleize unless @topic.user.state.nil? %>

--- a/app/views/notification_mailer/new_private.html.erb
+++ b/app/views/notification_mailer/new_private.html.erb
@@ -10,7 +10,7 @@
       <%= t('message_id', default: 'Message ID') %>:<%= @topic.id %></br>
     </p>
     <p>
-      <%= t('notify_new_private', user_name: @topic.user.name, default: 'A new private customer message has been received from %{user_name}:') %>
+      <%= t('notify_new_private', user_name: @topic.user_name, default: 'A new private customer message has been received from %{user_name}:') %>
     </p>
     <p>
       <%= simple_format(@topic.posts.last.body) %>

--- a/app/views/notification_mailer/new_private.text.erb
+++ b/app/views/notification_mailer/new_private.text.erb
@@ -2,7 +2,7 @@
 =================================================================
 <%= t('message_id', default: 'Message ID') %>:<%= @topic.id %>
 
-<%= t('notify_new_private', user_name: @topic.user.name, default: 'A new private customer message has been received from %{user_name}:') %>
+<%= t('notify_new_private', user_name: @topic.user_name, default: 'A new private customer message has been received from %{user_name}:') %>
 
 <%= simple_format(@topic.posts.last.body) %>
 

--- a/app/views/notification_mailer/new_public.html.erb
+++ b/app/views/notification_mailer/new_public.html.erb
@@ -10,7 +10,7 @@
       <%= t('message_id', default: 'Message ID') %>:<%= @topic.id %></br>
     </p>
     <p>
-      <%= t('notify_new_public', user_name: @topic.user.name, default: "A new public customer message has been posted by %{user_name}:") %>
+      <%= t('notify_new_public', user_name: @topic.user_name, default: "A new public customer message has been posted by %{user_name}:") %>
     </p>
     <p>
       <%= simple_format(@topic.posts.last.body) %>

--- a/app/views/notification_mailer/new_public.text.erb
+++ b/app/views/notification_mailer/new_public.text.erb
@@ -2,7 +2,7 @@
 =================================================================
 <%= t('message_id', default: 'Message ID') %>:<%= @topic.id %>
 
-<%= t('notify_new_public', user_name: @topic.user.name, default: "A new public customer message has been posted by %{user_name}:") %>
+<%= t('notify_new_public', user_name: @topic.user_name, default: "A new public customer message has been posted by %{user_name}:") %>
 
 <%= simple_format(@topic.posts.last.body) %>
 

--- a/app/views/notification_mailer/new_reply.html.erb
+++ b/app/views/notification_mailer/new_reply.html.erb
@@ -10,7 +10,7 @@
       <%= t('message_id', default: 'Message ID') %>:<%= @topic.id %></br>
     </p>
     <p>
-      <%= t('notify_new_reply', user_name: @topic.user.name, default: "A new customer reply has been received from %{user_name}:") %>
+      <%= t('notify_new_reply', user_name: @topic.user_name, default: "A new customer reply has been received from %{user_name}:") %>
     </p>
     <p>
       <%= simple_format(@topic.posts.last.body) %>

--- a/app/views/notification_mailer/new_reply.text.erb
+++ b/app/views/notification_mailer/new_reply.text.erb
@@ -2,7 +2,7 @@
 =================================================================
 <%= t('message_id', default: 'Message ID') %>:<%= @topic.id %>
 
-<%= t('notify_new_reply', user_name: @topic.user.name, default: "A new customer reply has been received from %{user_name}:") %>
+<%= t('notify_new_reply', user_name: @topic.user_name, default: "A new customer reply has been received from %{user_name}:") %>
 
 <%= simple_format(@topic.posts.last.body) %>
 


### PR DESCRIPTION
There are quite a few occurrences of calling `user.name` on an instance of `Topic`, instead of using the cached version `user_name`. This fixes the occurrences that I could spot.