### PR TITLE
restrict format if email from name is not present

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -183,7 +183,11 @@ class Topic < ActiveRecord::Base
   private
 
   def cache_user_name
-    self.user_name = self.user.name
+    if self.user.name.present?
+      self.user_name = self.user.name
+    else
+      "NA"
+    end
   end
 
   def add_locale

--- a/lib/email_processor.rb
+++ b/lib/email_processor.rb
@@ -84,7 +84,7 @@ class EmailProcessor
       message = "Attachments:" if @email.attachments.present? && @email.body.blank?
       post = topic.posts.create(
         :body => message,
-        :raw_email => raw,        
+        :raw_email => raw,
         :user_id => @user.id,
         :kind => "first"
       )
@@ -128,7 +128,7 @@ class EmailProcessor
     @user.reset_password_sent_at = Time.now.utc
 
     @user.email = @email.from[:email]
-    @user.name = @email.from[:name].blank? ? @email.from[:token] : @email.from[:name]
+    @user.name = @email.from[:name].blank? ? @email.from[:token].gsub(/[^a-zA-Z]/, '') : @email.from[:name]
     @user.password = User.create_password
     if @user.save
       UserMailer.new_user(@user.id, @token).deliver_later

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -8,6 +8,38 @@ FactoryGirl.define do
     body 'Hello!'
   end
 
+  factory :email_from_unknown_name_missing, class: OpenStruct do
+    to [{ full: 'to_user@email.com', email: 'to_user@email.com', token: 'to_user', host: 'email.com', name: nil }]
+    from({ token: 'from_user', host: 'email.com', email: 'from_email@email.com', full: 'from_user@email.com', name: '' })
+    subject 'email subject'
+    header {}
+    body 'Hello!'
+  end
+
+  factory :email_from_known_token_numbers, class: OpenStruct do
+    to [{ full: 'to_user@email.com', email: 'to_user@email.com', token: 'to_user', host: 'email.com', name: nil }]
+    from({ token: 'from_user.me7731', host: 'email.com', email: 'from_user.me7731@email.com', full: 'from_user.me7731@email.com', name: '' })
+    subject 'email subject'
+    header {}
+    body 'Hello!'
+  end
+
+  factory :email_to_multiple, class: OpenStruct do
+    to [{ full: 'to_user@email.com <to_user@email.com>, second_user <second_user@email.com>', email: 'to_user@email.com, second_user@email.com', token: 'to_user', host: 'email.com', name: nil }]
+    from({ token: 'from_user', host: 'email.com', email: 'from_email@email.com', full: 'From User <from_user@email.com>', name: 'From User' })
+    subject 'email subject'
+    header {}
+    body 'Hello!'
+  end
+
+  factory :email_to_quoted, class: OpenStruct do
+    to [{ full: '"to_user@email.com" <to_user@email.com>', email: '"to_user@email.com"', token: 'to_user', host: 'email.com', name: nil }]
+    from({ token: 'from_user', host: 'email.com', email: 'from_email@email.com', full: '"From User" <from_user@email.com>', name: 'From User' })
+    subject 'email subject'
+    header {}
+    body 'Hello!'
+  end
+
   factory :email_from_unknown_with_attachments, class: OpenStruct do
     to [{ full: 'to_user@email.com', email: 'to_user@email.com', token: 'to_user', host: 'email.com', name: nil }]
     from({ token: 'from_user', host: 'email.com', email: 'from_email@email.com', full: 'From User <from_user@email.com>', name: 'From User' })

--- a/test/lib/email_processor_test.rb
+++ b/test/lib/email_processor_test.rb
@@ -18,6 +18,54 @@ class EmailProcessorTest < ActiveSupport::TestCase
     end
   end
 
+  test 'an email to the support address with no name should create a new user and topic with status new' do
+    assert_difference('Topic.where(current_status: "new").count', 1) do
+      assert_difference('Post.count', 1) do
+        assert_difference('User.count', 1) do
+          assert_difference('ActionMailer::Base.deliveries.size', 2) do
+            EmailProcessor.new(FactoryGirl.build(:email_from_unknown_name_missing)).process
+          end
+        end
+      end
+    end
+  end
+
+  test 'an email to the support address with email with numbers should create a new user and topic with status new' do
+    assert_difference('Topic.where(current_status: "new").count', 1) do
+      assert_difference('Post.count', 1) do
+        assert_difference('User.count', 1) do
+          assert_difference('ActionMailer::Base.deliveries.size', 2) do
+            EmailProcessor.new(FactoryGirl.build(:email_from_known_token_numbers)).process
+          end
+        end
+      end
+    end
+  end
+
+  test 'an email to the support address sent to multiple addresses create a new user and topic with status new' do
+    assert_difference('Topic.where(current_status: "new").count', 1) do
+      assert_difference('Post.count', 1) do
+        assert_difference('User.count', 1) do
+          assert_difference('ActionMailer::Base.deliveries.size', 2) do
+            EmailProcessor.new(FactoryGirl.build(:email_to_multiple)).process
+          end
+        end
+      end
+    end
+  end
+
+  test 'an email to the support address using quotes should create a new user and topic with status new' do
+    assert_difference('Topic.where(current_status: "new").count', 1) do
+      assert_difference('Post.count', 1) do
+        assert_difference('User.count', 1) do
+          assert_difference('ActionMailer::Base.deliveries.size', 2) do
+            EmailProcessor.new(FactoryGirl.build(:email_to_quoted)).process
+          end
+        end
+      end
+    end
+  end
+
   test 'an email with one attachment should save that attachment' do
 
     assert_difference('Topic.count', 1) do
@@ -31,13 +79,11 @@ class EmailProcessorTest < ActiveSupport::TestCase
   end
 
   test 'an email with multiple attachments should save those attachments' do
-
     assert_difference('Topic.count', 1) do
       assert_difference('Post.count', 1) do
         EmailProcessor.new(FactoryGirl.build(:email_from_unknown_with_attachments, :with_multiple_attachments)).process
       end
     end
-
     assert_equal "logo.png", Post.last.attachments.first.file.file.split("/").last
     assert_equal 2, Topic.last.posts.first.attachments.count
   end


### PR DESCRIPTION
Fixes #367 

Handle cases where the email token value needs to be used for the user name, but does not pass validation (ie. containers numbers etc.)