### PR TITLE
Bump `grape-entity` to `0.6.0`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
       activesupport (>= 4.0)
       grape (~> 0.16)
       redis-namespace (~> 1.5)
-    grape-entity (0.5.1)
+    grape-entity (0.6.0)
       activesupport
       multi_json (>= 1.3.2)
     grape-kaminari (0.1.9)
@@ -695,4 +695,4 @@ RUBY VERSION
    ruby 2.2.1p85
 
 BUNDLED WITH
-   1.13.5
+   1.13.6


### PR DESCRIPTION
`grape-entity < 0.6.0` has a known security vulnerability. Which was
fixed in ruby-grape/grape-entity#250

Closes #455

Thanks @connorshea