### PR TITLE
Truncate Post Body

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -26,6 +26,7 @@ class Post < ActiveRecord::Base
   mount_uploaders :attachments, AttachmentUploader
 
   validates :body, length: { maximum: 10_000 }
+  before_validation :truncate_body
   validates :kind, :user, :user_id, :body, presence: true
 
 
@@ -112,5 +113,13 @@ class Post < ActiveRecord::Base
     return I18n.locale if self.kind == 'first'
     self.topic.locale.nil? ? I18n.locale : self.topic.locale.to_sym
   end
+
+  private
+
+    def truncate_body
+      if not self.body.blank?
+        self.body = self.body.truncate(10_000)
+      end
+    end
 
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -117,9 +117,7 @@ class Post < ActiveRecord::Base
   private
 
     def truncate_body
-      if not self.body.blank?
-        self.body = self.body.truncate(10_000)
-      end
+      self.body = body.truncate(10_000) unless body.blank?
     end
 
 end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -211,7 +211,7 @@ class PostTest < ActiveSupport::TestCase
     @topic = Topic.create(forum_id: 1, name: "Test topic", user_id: @user.id)
     @post = @topic.posts.create(body: body, kind: "first", user_id: @user.id)
 
-    assert @post.body.size == 10000
+    assert_equal @post.body.size, 10_000
   end
 
 end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -26,7 +26,6 @@ class PostTest < ActiveSupport::TestCase
   should validate_presence_of(:body)
   should validate_presence_of(:kind)
   should validate_presence_of(:user)
-  should validate_length_of(:body).is_at_most(10_000)
 
   # first post should be kind first
   # post belonging to a topic with multiple posts should be a reply
@@ -203,6 +202,16 @@ class PostTest < ActiveSupport::TestCase
         kind: "note"
       )
     end
+  end
+
+  test "Should truncate body length if greater than 10,000" do
+    body = "0" * 10001
+    @user = User.first
+
+    @topic = Topic.create(forum_id: 1, name: "Test topic", user_id: @user.id)
+    @post = @topic.posts.create(body: body, kind: "first", user_id: @user.id)
+
+    assert @post.body.size == 10000
   end
 
 end


### PR DESCRIPTION
This truncates the post body to 10,000 characters during validation. Fixes #425