### PR TITLE
Reject unsupported file types in attachments

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -53,8 +53,10 @@ class PostsController < ApplicationController
             redirect_to @topic.doc.nil? ? topic_posts_path(@topic.id) : doc_path(@topic.doc_id)
           else
             # This post belongs to a ticket
-            agent = User.find(@topic.assigned_user_id)
-            tracker("Agent: #{agent.name}", "User Replied", @topic.to_param) #TODO: Need minutes
+            if @topic.try(:assigned_user_id)
+              agent = User.find(@topic.assigned_user_id)
+              tracker("Agent: #{agent.name}", "User Replied", @topic.to_param) #TODO: Need minutes
+            end
             redirect_to ticket_path(@topic.id)
           end
         }
@@ -66,7 +68,16 @@ class PostsController < ApplicationController
           end
         }
       else
-        format.html { render :action => "new" }
+        format.html {
+          flash[:error] = @post.errors.full_messages.first
+          if @topic.public?
+            # This is a forum post
+            redirect_to @topic.doc.nil? ? topic_posts_path(@topic.id) : doc_path(@topic.doc_id)
+          else
+            # This post belongs to a ticket
+            redirect_to ticket_path(@topic.id)
+          end
+          }
       end
     end
   end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -141,8 +141,8 @@ class TopicsController < ApplicationController
       @topic.user_id = @user.id
     end
 
-    if @user.save && @topic.save
-      @post = @topic.posts.create(
+    if @user.save && @topic.valid?
+      @post = @topic.posts.build(
         :body => params[:topic][:posts_attributes]["0"][:body],
         :user_id => @user.id,
         :kind => 'first',
@@ -150,7 +150,7 @@ class TopicsController < ApplicationController
         :attachments => params[:topic][:posts_attributes]["0"][:attachments])
     end
 
-    if @topic.save
+    if @topic.save && @post.save
       if built_user == true && !user_signed_in?
         UserMailer.new_user(@user.id, @token).deliver_later
       end
@@ -169,8 +169,7 @@ class TopicsController < ApplicationController
         @widget = true
         render 'new', layout: 'widget'
       else
-        flash[:error] = @topic.errors.full_messages.first
-        redirect_to new_topic_path
+        render :new
       end
     end
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -148,7 +148,11 @@ class TopicsController < ApplicationController
         :kind => 'first',
         :screenshots => params[:topic][:screenshots],
         :attachments => params[:topic][:posts_attributes]["0"][:attachments])
+    end
 
+    @topic.errors.add(:attachments, "Not valid format") unless @post.errors.empty?
+
+    if @topic.save
       if built_user == true && !user_signed_in?
         UserMailer.new_user(@user.id, @token).deliver_later
       end
@@ -167,7 +171,8 @@ class TopicsController < ApplicationController
         @widget = true
         render 'new', layout: 'widget'
       else
-        render 'new'
+        flash[:error] = @topic.errors.full_messages.first
+        redirect_to new_topic_path
       end
     end
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -150,7 +150,7 @@ class TopicsController < ApplicationController
         :attachments => params[:topic][:posts_attributes]["0"][:attachments])
     end
 
-    @topic.errors.add(:attachments, "Not valid format") unless @post.errors.empty?
+    @topic.validate_attachment_format(@post.errors)
 
     if @topic.save
       if built_user == true && !user_signed_in?

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -150,8 +150,6 @@ class TopicsController < ApplicationController
         :attachments => params[:topic][:posts_attributes]["0"][:attachments])
     end
 
-    @topic.validate_attachment_format(@post.errors)
-
     if @topic.save
       if built_user == true && !user_signed_in?
         UserMailer.new_user(@user.id, @token).deliver_later

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -180,6 +180,10 @@ class Topic < ActiveRecord::Base
     )
   end
 
+  def validate_attachment_format(post_errors)
+    errors.add(:attachments, "Not valid format") if post_errors.present?
+  end
+
   private
 
   def cache_user_name

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -79,6 +79,7 @@ class Topic < ActiveRecord::Base
   acts_as_taggable_on :teams
 
   validates :name, presence: true, length: { maximum: 255 }
+  validate :validate_attachment_format, on: :create
 
   def to_param
     "#{id}-#{name.parameterize}"
@@ -180,8 +181,10 @@ class Topic < ActiveRecord::Base
     )
   end
 
-  def validate_attachment_format(post_errors)
-    errors.add(:attachments, "Not valid format") if post_errors.present?
+  def validate_attachment_format
+    if self.posts.any? && self.posts.last.errors[:attachments].any?
+      errors.add(:attachments, "attachment format is not valid")
+    end
   end
 
   private

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -79,7 +79,6 @@ class Topic < ActiveRecord::Base
   acts_as_taggable_on :teams
 
   validates :name, presence: true, length: { maximum: 255 }
-  validate :validate_attachment_format, on: :create
 
   def to_param
     "#{id}-#{name.parameterize}"
@@ -179,12 +178,6 @@ class Topic < ActiveRecord::Base
       user_id: @user.id,
       doc_id: @doc.id
     )
-  end
-
-  def validate_attachment_format
-    if self.posts.any? && self.posts.last.errors[:attachments].any?
-      errors.add(:attachments, "attachment format is not valid")
-    end
   end
 
   private

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -47,7 +47,7 @@
     </script>
     <% end %>
 
-    <%= f.input(:team_list, collection: @all_teams, :label => t(:assign_to), locale: I18n.locale, prompt: "", style: "display:none;") if teams? and !@widget and @all_teams.count > 0 %>
+    <%= f.input(:team_list, collection: @all_teams, :label => t(:assign_to), locale: I18n.locale, prompt: "", style: "display:none;") if teams? and !@widget and @all_teams.present? and @all_teams.count > 0 %>
     <%= f.input :name, input_html: { value: params[:q] }, :size => 40,  placeholder: I18n.t(:subject), label: I18n.t(:subject), class: 'disable-empty topic-placeholder' %>
 
     <div class="suggestion-results-container hidden">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -370,3 +370,6 @@ en:
       save: "Save %{model}"
       new: "New %{model}"
       delete: "Delete %{model}"
+  errors:
+    messages:
+      extension_whitelist_error: 'format is not valid'

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -107,4 +107,19 @@ class PostsControllerTest < ActionController::TestCase
     assert :success
     assert_equal "logo.png", Post.last.attachments.first.file.file.split("/").last
   end
+
+  test "a signed in user should not be able to add an attachment with not supported format" do
+    sign_in users(:user)
+    assert_difference "Post.count", 0 do
+      post :create,
+        topic_id: 1,
+        locale: :en,
+        post: {
+          user_id: User.find(2).id,
+          body: "new reply",
+          kind: "reply",
+          attachments: Array.wrap(uploaded_file_object(Post, :attachments, File.open(File.expand_path('test/fixtures/files/upload_test.rb'))))
+        }
+    end
+  end
 end

--- a/test/controllers/topics_controller_test.rb
+++ b/test/controllers/topics_controller_test.rb
@@ -177,6 +177,38 @@ class TopicsControllerTest < ActionController::TestCase
     assert_redirected_to topic_thanks_path, 'Did not redirect to thanks view'
   end
 
+  # A user who is signed in should not be able to attach file with not supported format to new topic
+  test 'a signed in user should not be able to attach file with not supported format to new topic' do
+    sign_in users(:user)
+
+    get :new, locale: :en
+    assert_response :success
+
+    assert_difference 'Topic.count', 0, 'A topic should not have been created' do
+      assert_difference 'Post.count', 0, 'A post should not have been created' do
+        post :create,
+          topic: {
+            user: {
+              name: 'a user',
+              email: 'anon@test.com'
+              },
+            name: 'some new public topic',
+            body: 'some body text',
+            forum_id: 1,
+            private: true,
+            posts_attributes: {
+              :"0" => {
+              body: "this is the body",
+              attachments: Array.wrap(uploaded_file_object(Post, :attachments, File.open(File.expand_path('test/fixtures/files/upload_test.rb'))))
+              }
+            }
+          },
+          locale: :en
+      end
+    end
+
+    assert_template :new
+  end
 
   # A user who is registered, but not signed in currently should be able to create a new private
   # or public topic

--- a/test/fixtures/files/upload_test.rb
+++ b/test/fixtures/files/upload_test.rb
@@ -1,0 +1,1 @@
+upload_test

--- a/test/fixtures/files/upload_test.rb
+++ b/test/fixtures/files/upload_test.rb
@@ -1,1 +1,4 @@
-upload_test
+# this file is just for testing upload attachments
+
+def upload_test
+end


### PR DESCRIPTION
Fixes https://github.com/helpyio/helpy/issues/442
Error message is displayed if user upload file with unsupported format.