### PR TITLE
Resolve deprecation warnings in minitest

### DIFF
--- a/test/models/topic_test.rb
+++ b/test/models/topic_test.rb
@@ -121,7 +121,7 @@ class TopicTest < ActiveSupport::TestCase
     topic = Topic.create!(name: name, user_id: 1, forum_id: 1)
     topic.close
     assert_equal 'closed', topic.current_status
-    assert_equal nil, topic.assigned_user_id
+    assert_nil topic.assigned_user_id
   end
 
   test "#trash should set the current_status of the topic to trash, assigned_user_id to nil, and should create a closed_message post belonging to that topic" do
@@ -129,7 +129,7 @@ class TopicTest < ActiveSupport::TestCase
     t_posts_count = topic.posts.count
     topic.trash
     assert_equal 'trash', topic.current_status
-    assert_equal nil, topic.assigned_user_id
+    assert_nil topic.assigned_user_id
     assert_equal t_posts_count + 1, topic.posts.count
   end
 


### PR DESCRIPTION
The use of `assert_equal` to check for `nil`, will be deprecated in
minitest 6.