### PR TITLE
Implement the `User#active` behaviour

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,3 +1,14 @@
 class SessionsController < Devise::SessionsController
   theme :theme_chosen
+
+  def create
+    super do |resource|
+      unless resource.active
+        sign_out(resource)
+        flash[:notice] = nil
+        redirect_to root_path, alert: 'Your account is inactive.'
+        return
+      end
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,10 @@ Rails.application.routes.draw do
   get 'widget/' => 'widget#index', as: :widget
   get 'widget/thanks' => 'widget#thanks', as: :widget_thanks
 
-  devise_for :users, skip: [:password, :registration, :confirmation, :invitations], controllers: { omniauth_callbacks: 'omniauth_callbacks' }
+  devise_for :users, skip: [:password, :registration, :confirmation, :invitations], controllers: {
+    omniauth_callbacks: 'omniauth_callbacks',
+    sessions: 'sessions'
+  }
 
   as :user do
     get "/users/invitation/accept" => "devise/invitations#edit", as: :accept_user_invitation

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class SessionsControllerTest < ActionController::TestCase
+
+  setup do
+    @request.env["devise.mapping"] = Devise.mappings[:user]
+    set_default_settings
+  end
+
+  test "allows sign in of a active user" do
+    post :create, user: { email: 'scott.smith@test.com', password: '12345678' }
+    assert_redirected_to root_path
+    assert_equal 'Signed in successfully.', flash[:notice]
+  end
+
+  test "denies sign in of a non-active user" do
+    post :create, user: { email: 'not_active@test.com', password: '12345678' }
+    assert_redirected_to root_path
+    assert_equal "Your account is inactive.", flash[:alert]
+  end
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -90,6 +90,7 @@ user2:
   identity_url: MyString
   name: Scott Smith
   email: scott.smith@test.com
+  encrypted_password: $2a$10$NDaQ2l6.7dqkWTbqZGX6RuokqiUrfrcouiKc3YCGKIvz9KxhPt7uK
   admin: false
   role: user
 
@@ -138,3 +139,14 @@ editor:
   admin: false
   role: editor
   encrypted_password: $2a$10$NDaQ2l6.7dqkWTbqZGX6RuokqiUrfrcouiKc3YCGKIvz9KxhPt7uK
+
+user3:
+  id: 8
+  login: waddup
+  identity_url: MyString
+  name: Not Active
+  email: not_active@test.com
+  admin: false
+  role: user
+  encrypted_password: $2a$10$NDaQ2l6.7dqkWTbqZGX6RuokqiUrfrcouiKc3YCGKIvz9KxhPt7uK
+  active: false


### PR DESCRIPTION
Only `active` users should be allowed to sign in.

Overrides the `Devise::SessionsController#create` action, checks if a user is active, signs them back out if they are not.

Closes #476 