### PR TITLE
Update Carrierwave to 1.0.0.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,9 +86,8 @@ gem 'gravtastic'
 # File handling
 gem 'cloudinary', '1.1.2'
 gem 'attachinary'
-# TODO NOTE Carrierwave currently requires master to use multiple files functionality
-# This should be changed as soon as a stable branch is available
-gem 'carrierwave', git: 'https://github.com/carrierwaveuploader/carrierwave'
+
+gem 'carrierwave', '~> 1.0.0'
 gem "jquery-fileupload-rails"
 gem 'mini_magick'
 
@@ -167,7 +166,6 @@ group :development do
 
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'
-
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/carrierwaveuploader/carrierwave
-  revision: ec850831eeaf0f2f45c002bcec9b90698b78d0d8
-  specs:
-    carrierwave (1.0.0.beta)
-      activemodel (>= 4.0.0)
-      activesupport (>= 4.0.0)
-      mime-types (>= 1.16)
-
-GIT
   remote: https://github.com/railsconfig/config.git
   revision: 813e504f47d370bc9b5847dce772828445e9dad7
   specs:
@@ -117,6 +108,10 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    carrierwave (1.0.0)
+      activemodel (>= 4.0.0)
+      activesupport (>= 4.0.0)
+      mime-types (>= 1.16)
     celluloid (0.16.0)
       timers (~> 4.0.0)
     childprocess (0.5.9)
@@ -598,7 +593,7 @@ DEPENDENCIES
   bundler-audit
   byebug
   capybara
-  carrierwave!
+  carrierwave (~> 1.0.0)
   client_side_validations
   client_side_validations-simple_form
   cloudinary (= 1.1.2)
@@ -694,4 +689,4 @@ RUBY VERSION
    ruby 2.2.1p85
 
 BUNDLED WITH
-   1.13.6
+   1.13.7


### PR DESCRIPTION
Changelog: https://github.com/carrierwaveuploader/carrierwave/blob/9ef68325dd5ea465b4d340af9a9def10934cd677/CHANGELOG.md#100---2016-12-24