### PR TITLE
Revert "Relax required Ruby version"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,9 @@
 language: ruby
 rvm:
-  - 2.2.5
-  - 2.3.1
+  - 2.2.1
 
 services:
   - postgresql
-
-before_install:
-  # Install a current Bundler version
-  - gem install bundler
 
 before_script:
   # Setup Test Database

--- a/Gemfile
+++ b/Gemfile
@@ -189,4 +189,4 @@ group :production do
   gem 'unicorn'
 end
 
-ruby '>= 2.2', '< 2.4'
+ruby "2.2.1"


### PR DESCRIPTION
Reverts helpyio/helpy#339- Broken Travis with "no env variable set"