### PR TITLE
populate @posts when creating a new ticket from admin

### DIFF
--- a/app/controllers/admin/topics_controller.rb
+++ b/app/controllers/admin/topics_controller.rb
@@ -136,6 +136,9 @@ class Admin::TopicsController < Admin::BaseController
         tracker('Request', 'Post', 'New Topic')
         tracker('Agent: Unassigned', 'New', @topic.to_param)
 
+        # Now that we are rendering show, get the posts (just one)
+        # TODO probably can refactor this
+        @posts = @topic.posts.chronologic.includes(:user)
         format.js {
           render action: 'show', id: @topic
 


### PR DESCRIPTION
This fixes a bug where the new message is not properly displayed in the `show` view.