### PR TITLE
Relax required Ruby version (2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: ruby
 rvm:
-  - 2.2.1
+  - 2.2.5
+  - 2.3.1
 
 services:
   - postgresql
+
+before_install:
+  # Install a current Bundler version
+  - gem install bundler
 
 before_script:
   # Setup Test Database

--- a/Gemfile
+++ b/Gemfile
@@ -189,4 +189,4 @@ group :production do
   gem 'unicorn'
 end
 
-ruby "2.2.1"
+ruby '>= 2.2', '< 2.4'


### PR DESCRIPTION
If an exact Ruby version is specified in the Gemfile, bundler will abort with an error if a newer,
yet compatible, Ruby interpreter is used. Thus, only specify the minimum required version,
simplifying the setup of Helpy on systems where a current Ruby interpreter is available.

Using Ruby version operators is only supported by newer Bundler versions, so make the current one
available in the Travis CI environment. Also test the latest version of each compatible Ruby release
on Travis CI.

This is a follow-up to #339 .