### PR TITLE
[WIP] allow tickets to be viewed and replied to via secret url

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -41,10 +41,22 @@ class PostsController < ApplicationController
   end
 
   def create
-    @topic = Topic.find(params[:topic_id])
-    @post = @topic.posts.new(post_params)
+    if params[:topic_code]
+      @topic = Topic.find_by_code(params[:topic_code])
+      @post = @topic.posts.new(post_params)
+      if user_signed_in?
+        @post.user_id = current_user.id
+      else
+        @post.user_id = @topic.user.id
+      end
+    elsif params[:topic_id] && user_signed_in?
+      @topic = Topic.find(params[:topic_id])
+      @post = @topic.posts.new(post_params)
+      @post.user_id = current_user.id
+    else
+      raise ArgumentError, 'either topic_code or topic_id must be in params'
+    end
     @post.topic_id = @topic.id
-    @post.user_id = current_user.id
     @post.screenshots = params[:post][:screenshots]
 
     respond_to do |format|

--- a/app/models/auto_user.rb
+++ b/app/models/auto_user.rb
@@ -1,0 +1,45 @@
+#
+# A class for automatically generated users
+#
+
+require 'securerandom'
+
+class AutoUser < User
+  # tell devise that email is optional
+  def email_required?; false; end
+
+  before_validation :signup_guest, :on => :create
+
+  #
+  # this will make the form helpers treat AutoUser just
+  # as if it was a User.
+  #
+  def self.model_name
+    ActiveModel::Name.new(User)
+  end
+
+  def initialize(*args)
+    super
+
+    # We don't want email required for AutoUsers, at least not in the forms.
+    # The only way to remove a validation set in a super class is to modify the
+    # _validators variable. Here we remove the validator set in user.rb on
+    # email. We can leave the ones set by devise, because of email_required?()
+    _validators[:email].delete_if do |v|
+      v.is_a?(ActiveRecord::Validations::PresenceValidator) && v.options.empty?
+    end
+  end
+
+  def signup_guest
+    # the .invalid TLD is reserved for uses like this
+    if !self.email.present?
+      self.email = SecureRandom.hex(10) + "@email.invalid"
+    end
+    enc = Devise.token_generator.generate(User, :reset_password_token)
+    self.reset_password_token = enc
+    self.reset_password_sent_at = Time.now.utc
+    self.login = self.email.split("@")[0]
+    self.password = User.create_password
+  end
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -186,17 +186,6 @@ class User < ActiveRecord::Base
     "#{id}-#{name.parameterize}"
   end
 
-  def signup_guest
-    enc = Devise.token_generator.generate(User, :reset_password_token)
-    self.reset_password_token = enc
-    self.reset_password_sent_at = Time.now.utc
-
-    self.login = self.email.split("@")[0]
-    self.password = User.create_password
-    self.save
-  end
-
-
   # NOTE: Could have user AR Enumerables for this, but the field was already in the database as a string
   # and changing it could be painful for upgrading installed users. These are three
   # Utility methods for checking the role of an admin:
@@ -211,6 +200,12 @@ class User < ActiveRecord::Base
 
   def is_editor?
     %w( editor agent admin ).include?(self.role)
+  end
+
+  def email_valid?
+    self.email.present? &&
+    self.email !~ /\A#{Regexp.escape(TEMP_EMAIL_PREFIX)}/ &&
+    self.email !~ /@email.invalid\z/
   end
 
   def self.bulk_invite(emails, message, role)

--- a/app/views/topics/ticket.html.erb
+++ b/app/views/topics/ticket.html.erb
@@ -38,17 +38,20 @@
     <div id="posts">
       <%= render :partial => 'posts/post', :collection => @posts %>
     </div>
-    <% if user_signed_in? %>
+    <% if user_signed_in? || @access_by_code %>
       <div class="add-form">
       <h4><%= I18n.t("reply", default: "Reply to this Topic") %></h4>
       <%#= error_messages_for :post -%>
       <%= bootstrap_form_for @topic.posts.new, :url => topic_posts_path(@topic), :remote => true do |f| -%>
         <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
+        <% if @access_by_code %>
+          <%= hidden_field_tag :topic_code, @topic.code -%>
+        <% end %>
         <%= f.hidden_field 'kind', value: 'reply' %>
         <%= hidden_field_tag :client_id %>
         <%= f.text_area :body, :rows => 8, :cols => 160, skip_label: true, class: 'disable-empty' -%></p>
         <%= f.attachinary_file_field :screenshots if cloudinary_enabled? %>
-        <%= f.file_field :attachments, multiple: true unless cloudinary_enabled? %>				
+        <%= f.file_field :attachments, multiple: true unless cloudinary_enabled? %>
         <%= f.submit I18n.t('submit_reply', default: 'Post Reply'), class: 'btn btn-warning disableable', disabled: 'disabled' -%>
       <% end -%>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,6 +69,9 @@ en:
   ticket_number: "Ticket Number"
   assigned_to_label: "Assigned to"
   created_on: "Created on"
+  ticket_secret_url_notice: |
+    You are viewing this ticket using the secret link %{url}.
+    Anyone with this link can view and reply to this ticket.
 
   # Get Help
   get_help_header: "Still Need Help?"

--- a/db/migrate/20170210192041_add_code_to_topics.rb
+++ b/db/migrate/20170210192041_add_code_to_topics.rb
@@ -1,0 +1,6 @@
+class AddCodeToTopics < ActiveRecord::Migration
+  def change
+    add_column :topics, :code, :string
+    add_index :topics, :code
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161204162759) do
+ActiveRecord::Schema.define(version: 20170210192041) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -226,7 +226,10 @@ ActiveRecord::Schema.define(version: 20161204162759) do
     t.string   "locale"
     t.integer  "doc_id",           default: 0
     t.string   "channel",          default: "email"
+    t.string   "code"
   end
+
+  add_index "topics", ["code"], name: "index_topics_on_code", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "login"

--- a/test/controllers/topics_controller_test.rb
+++ b/test/controllers/topics_controller_test.rb
@@ -146,7 +146,7 @@ class TopicsControllerTest < ActionController::TestCase
       post :create, topic: { user: { name: 'a user', email: 'anon@test.com' }, name: 'some new public topic', body: 'some body text', forum_id: 1, private: true, posts_attributes: {:"0" => {body: "this is the body"}} }, locale: :en
     end
 
-    assert_redirected_to topic_thanks_path, 'Did not redirect to thanks view'
+    assert_redirected_to ticket_path(Topic.last.code), 'Did not redirect to thanks view'
   end
 
   # A user who is signed in should be able to create a new private or public topic and attach a file
@@ -180,7 +180,7 @@ class TopicsControllerTest < ActionController::TestCase
     end
 
     assert_equal "logo.png", Post.last.attachments.first.file.file.split("/").last
-    assert_redirected_to topic_thanks_path, 'Did not redirect to thanks view'
+    assert_redirected_to ticket_path(Topic.last.code), 'Did not redirect to thanks view'
   end
 
 
@@ -197,7 +197,7 @@ class TopicsControllerTest < ActionController::TestCase
       end
     end
 
-    assert_redirected_to topic_thanks_path, 'Did not redirect to thanks view'
+    assert_redirected_to ticket_path(Topic.last.code), 'Did not redirect to thanks view'
   end
 
   test 'a signed in user should not see trashed topics in a public forum' do
@@ -300,7 +300,7 @@ class TopicsControllerTest < ActionController::TestCase
       end
     end
 
-    assert_redirected_to topic_thanks_path, "Did not redirect to thanks view"
+    assert_redirected_to ticket_path(Topic.last.code), "Did not redirect to thanks view"
   end
 
   test "a signed in user should be able to create a new public discussion if forums are enabled" do

--- a/test/integration/browsing_user_ticket_flows_test.rb
+++ b/test/integration/browsing_user_ticket_flows_test.rb
@@ -34,8 +34,7 @@ class BrowsingUserTicketFlowsTest < ActionDispatch::IntegrationTest
         click_on('Create Ticket', disabled: true)
       end
     end
-    assert current_path == '/en/thanks'
-
+    assert current_path =~ %r(/en/ticket/.)
   end
 
   test "a browsing user who is not registered should be able to create a public ticket via the web interface when recaptcha enable" do


### PR DESCRIPTION
This PR adds "codes" to topics, so that tickets may be viewed and replied to via a secret URL.

The desire for this change comes from a need to make "email" an optional field for creating a new ticket when not authenticated (we don't want to require an email address when asking questions of an email provider). 

I don't know if something like this would be welcome in helpy, but if so, then here is one possible solution. This current PR is not particularly clean, but I am pushing it here to stimulate a conversation. 

The approach taken here is to use a random string for the user.email field if email is missing, since there is an index on the email column that requires an unique value.

The disadvantage of this is that a new user is created for every anonymous ticket, and that new user is never destroyed. Before, when email was required, when the same person created a second ticket, the email address could be used to fetch the existing user object to associate with the new ticket.

This is not really a problem, but it does suggest that it would be good to create scripts to clean out old users and old closed private topics.