### PR TITLE
Adding some translate features, and adjusting pt-br translation

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -73,7 +73,9 @@ class Admin::SettingsController < Admin::BaseController
     @logo.file = params['uploader.design.header_logo']
     @logo.save
 
-    flash[:success] = "The changes you have been saved.  Some changes are only visible on your helpcenter site: #{AppSettings['settings.site_url']}"
+    flash[:success] = t(:settings_changes_saved,
+                        site_url: AppSettings['settings.site_url'],
+                        default: "The changes you have been saved.  Some changes are only visible on your helpcenter site: #{AppSettings['settings.site_url']}")
     respond_to do |format|
       format.html {
         redirect_to admin_settings_path

--- a/app/views/admin/dashboard/stats.html.erb
+++ b/app/views/admin/dashboard/stats.html.erb
@@ -22,7 +22,7 @@
             <%= form_tag admin_stats_path, class: 'form-horizontal dropdown-form', method: :get do %>
               <%= hidden_field_tag :label, 'interval' %>
               <div class="form-group">
-                <%= label_tag 'Start:', nil, class: 'col-sm-2 control-label' %>
+                <%= label_tag t(:insight_start_range, default: 'Start:'), nil, class: 'col-sm-2 control-label' %>
                 <div class="col-sm-10">
                   <div class="input-group date">
                     <%= text_field_tag :start_date, nil, class: 'form-control' %>
@@ -32,7 +32,7 @@
               </div>
 
               <div class="form-group">
-                <%= label_tag 'End:', nil, class: 'col-sm-2 control-label' %>
+                <%= label_tag t(:insight_end_range, default: 'End:'), nil, class: 'col-sm-2 control-label' %>
                 <div class="col-sm-10">
                   <div class="input-group date">
                     <%= text_field_tag :end_date, nil, class: 'form-control' %>
@@ -43,7 +43,7 @@
 
               <div class="form-group">
                 <div class="col-sm-offset-2 col-sm-10">
-                  <%= submit_tag 'Filter', class: 'btn btn-default' %>
+                  <%= submit_tag t(:insight_filter, default: 'Filter'), class: 'btn btn-default' %>
                 </div>
               </div>
             <% end %>

--- a/app/views/admin/topics/shortcuts.html.erb
+++ b/app/views/admin/topics/shortcuts.html.erb
@@ -1,47 +1,47 @@
 <div class="row keyboard-shortcuts">
   <div class="col-md-12">
-    <h3>Keyboard shortcuts</h3>
+    <h3><%= t(:keyboard_shortcuts, default: "Keyboard shortcuts") %></h3>
   </div>
 </div>
 <div class="row keyboard-shortcuts">
   <div class="col-sm-6 col-md-6">
-    <span class="text-left"><h4>Listing Views</h4></span>
+    <span class="text-left"><h4><%= t(:listing_views, default: "Listing Views") %></h4></span>
     <ul class="list-unstyled">
-      <li class="shortcut-row"><span class="key">G</span> then <span class="key">N</span> Show new tickets</li>
-      <li class="shortcut-row"><span class="key">G</span> then <span class="key">A</span> Show all tickets</li>
-      <li class="shortcut-row"><span class="key">G</span> then <span class="key">O</span> Show open tickets</li>
-      <li class="shortcut-row"><span class="key">G</span> then <span class="key">M</span> Show tickets assigned to you</li>
-      <li class="shortcut-row"><span class="key">G</span> then <span class="key">P</span> Show pending tickets assigned to you</li>
-      <li class="shortcut-row"><span class="key">G</span> then <span class="key">C</span> Show closed tickets</li>
-      <li class="shortcut-row"><span class="key">N</span> Show new tickets</li>
-      <li class="shortcut-row"><span class="key">F</span> Search for tickets</li>
+      <li class="shortcut-row"><span class="key">G</span> <%= t(:shortcut_then, default: "then") %> <span class="key">N</span> <%= t(:show_new_tickets, default: "Show new tickets") %></li>
+      <li class="shortcut-row"><span class="key">G</span> <%= t(:shortcut_then, default: "then") %> <span class="key">A</span> <%= t(:show_all_tickets, default: "Show all tickets") %></li>
+      <li class="shortcut-row"><span class="key">G</span> <%= t(:shortcut_then, default: "then") %> <span class="key">O</span> <%= t(:show_open_tickets, default: "Show open tickets") %></li>
+      <li class="shortcut-row"><span class="key">G</span> <%= t(:shortcut_then, default: "then") %> <span class="key">M</span> <%= t(:show_tickets_assigned_to_you, default: "Show tickets assigned to you") %></li>
+      <li class="shortcut-row"><span class="key">G</span> <%= t(:shortcut_then, default: "then") %> <span class="key">P</span> <%= t(:show_pending_tickets_assigned_to_you, default: "Show pending tickets assigned to you") %></li>
+      <li class="shortcut-row"><span class="key">G</span> <%= t(:shortcut_then, default: "then") %> <span class="key">C</span> <%= t(:show_closed_tickets, default: "Show closed tickets") %></li>
+      <li class="shortcut-row"><span class="key">N</span> <%= t(:show_new_tickets, default: "Show new tickets") %></li>
+      <li class="shortcut-row"><span class="key">F</span> <%= t(:search_for_tickets, default: "Search for tickets") %></li>
     </ul>
-    <span class="text-left"><h4>Viewing Tickets</h4></span>
+    <span class="text-left"><h4><%= t(:viewing_tickets, default: "Viewing Tickets") %></h4></span>
     <ul class="list-unstyled">
-      <li class="shortcut-row"><span class="key">,</span> Select Previous Ticket</li>
-      <li class="shortcut-row"><span class="key">.</span> Select Next Ticket</li>
-      <li class="shortcut-row"><span class="key">Enter</span> View Selected Ticket</li>
-      <li class="shortcut-row"><span class="key">#{ticket number}</span> Jump to a specific ticket number</li>
+      <li class="shortcut-row"><span class="key">,</span> <%= t(:select_previous_ticket, default: "Select Previous Ticket") %></li>
+      <li class="shortcut-row"><span class="key">.</span> <%= t(:select_next_ticket, default: "Select Next Ticket") %></li>
+      <li class="shortcut-row"><span class="key">Enter</span> <%= t(:view_selected_ticket, default: "View Selected Ticket") %></li>
+      <li class="shortcut-row"><span class="key">#{<%= t(:ticket_number, default: "ticket number") %>}</span> <%= t(:jump_to_a_specific_ticket_number, default: "Jump to a specific ticket number") %></li>
     </ul>
   </div>
   <div class="col-sm-6  col-md-6">
-    <span class="text-left"><h4>Ticket Actions</h4></span>
+    <span class="text-left"><h4><%= t(:ticket_actions, default: "Ticket Actions") %></h4></span>
     <ul class="list-unstyled">
-      <li class="shortcut-row"><span class="key">A</span> Assign the ticket</li>
-      <li class="shortcut-row"><span class="key">M</span> Move the ticket</li>
-      <li class="shortcut-row"><span class="key">X</span> Expand the ticket thread</li>
-      <li class="shortcut-row"><span class="key">R</span> Reply to the ticket</li>
-      <li class="shortcut-row"><span class="key">O</span> Add an internal note</li>
-      <li class="shortcut-row"><span class="key">U</span> Change the ticket status</li>
-      <li class="shortcut-row"><span class="key">P</span> Associate with a Group</li>
+      <li class="shortcut-row"><span class="key">A</span> <%= t(:assign_the_ticket, default: "Assign the ticket") %></li>
+      <li class="shortcut-row"><span class="key">M</span> <%= t(:move_the_ticket, default: "Move the ticket") %>x</li>
+      <li class="shortcut-row"><span class="key">X</span> <%= t(:expand_the_ticket_thread, default: "Expand the ticket thread") %></li>
+      <li class="shortcut-row"><span class="key">R</span> <%= t(:reply_to_the_ticket, default: "Reply to the ticket") %></li>
+      <li class="shortcut-row"><span class="key">O</span> <%= t(:add_an_internal_note, default: "Add an internal note") %></li>
+      <li class="shortcut-row"><span class="key">U</span> <%= t(:change_ticket_status, default: "Change the ticket status") %></li>
+      <li class="shortcut-row"><span class="key">P</span> <%= t(:associate_with_a_group, default: "Associate with a Group") %></li>
     </ul>
-    <span class="text-left"><h4>Ticket Status</h4></span>
+    <span class="text-left"><h4><%= t(:ticket_status, default: "Ticket Status") %></h4></span>
     <ul class="list-unstyled">
-      <li class="shortcut-row"><span class="key">S</span> then <span class="key">R</span> Mark resolved</li>
-      <li class="shortcut-row"><span class="key">S</span> then <span class="key">O</span> Re-open ticket</li>
-      <li class="shortcut-row"><span class="key">S</span> then <span class="key">N</span> Set to new</li>
-      <li class="shortcut-row"><span class="key">S</span> then <span class="key">S</span> Mark as spam</li>
-      <li class="shortcut-row"><span class="key">S</span> then <span class="key">T</span> Move to trash</li>
+      <li class="shortcut-row"><span class="key">S</span> <%= t(:shortcut_then, default: "then") %> <span class="key">R</span> <%= t(:mark_resolved, default: "Mark resolved") %></li>
+      <li class="shortcut-row"><span class="key">S</span> <%= t(:shortcut_then, default: "then") %> <span class="key">O</span> <%= t(:reopen_ticket, default: "Re-open ticket") %></li>
+      <li class="shortcut-row"><span class="key">S</span> <%= t(:shortcut_then, default: "then") %> <span class="key">N</span> <%= t(:set_to_new, default: "Set to new") %></li>
+      <li class="shortcut-row"><span class="key">S</span> <%= t(:shortcut_then, default: "then") %> <span class="key">S</span> <%= t(:mark_as_spam, default: "Mark as spam") %></li>
+      <li class="shortcut-row"><span class="key">S</span> <%= t(:shortcut_then, default: "then") %> <span class="key">T</span> <%= t(:move_to_trash, default: "Move to trash") %></li>
     </ul>
   </div>
 </div>

--- a/config/locales/pt_BR.yml
+++ b/config/locales/pt_BR.yml
@@ -153,8 +153,17 @@ pt-br:
   private: "privado"
   public: "público"
   save_changes: "Guardar Alterações"
-  #merge: Merge
-  #merge_confirm: Are you sure you want to merge these tickets?
+  merge: Mesclar
+  merge_confirm: Você tem certeza que deseja mesclar estes tickets?
+  settings_changes_saved: "Suas mudanças foram salvas. Algumas mudanças são visíveis somente diretamente no helpcenter: %{site_url}"
+
+  helpcenter: "Central de ajuda"
+  new_ticket: "Novo Ticket"
+  internal_content: "Conteúdo interno"
+  get_help: "Ajuda"
+  report_bug: "Reportar Bug"
+  suggest_feature: "Sugerir melhoria"
+  shortcuts: "Atalhos de teclado"
 
   # Discussion controls
   change_status: "Alterar Estado"
@@ -179,7 +188,7 @@ pt-br:
 
   # User Admin
   users: "Usuários"
-  # account: Account
+  account: Conta
   contact_info: "Contato"
   social_info: "Social"
   edit_user: "Editar Usuário"
@@ -187,11 +196,11 @@ pt-br:
   cell_phone: "celular"
 
   # Priorities
-  # select_priority: Select Priority
-  # vip_priority: VIP
-  # high_priority: High
-  # normal_priority: Normal
-  # low_priority: Low
+  select_priority: Selecionar prioridade
+  vip_priority: VIP
+  high_priority: Alta
+  normal_priority: Normal
+  low_priority: Baixa
 
   # User search results
   users_found:
@@ -243,10 +252,10 @@ pt-br:
   content_status: "Estado do Conteúdo"
   convert_content: 'Transformar postagem em conteúdo'
   upload_image: 'Carregar imagem'
-  # new_discussion: 'Create new discussion from this'
-  # new_discussion_post: 'Discussion #%{topic_id} was created from this one'
-  # new_discussion_topic_title: 'Split from #%{original_id}-%{original_name}'
-  # change_owner_note: 'The creator of this topic was changed from %{old} to %{new}'
+  new_discussion: 'Criar nova discussão a partir deste conteúdo'
+  new_discussion_post: 'Discussão #%{topic_id} foi criada a partir deste conteúdo'
+  new_discussion_topic_title: 'Originada de #%{original_id}-%{original_name}'
+  change_owner_note: 'O criador deste tópico modificou o título de %{old} para %{new}'
 
   # Communities
   new_community: "Criar uma Nova Comunidade"
@@ -257,7 +266,7 @@ pt-br:
   layout_qna: FAQ
 
   # Mail messages
-  new_user_subject: "Welcome to %{site_name}"
+  new_user_subject: "Bem vindo ao %{site_name}"
   hello: "Olá %{user_name}"
   new_user: "Obrigado pelo seu contato. A sua mensagem foi recebida pela nossa equipe de suporte e iremos entrar em contato o mais rapidamente possível."
   account_generated: "Foi criada uma nova conta para voce. Para fazer login, use este link:"
@@ -273,8 +282,12 @@ pt-br:
   yesterday: Ontem
   this_week: "Essa semana"
   last_week: "Última semana"
+  last_month: "Último mês"
   this_month: "Esse mês"
   date_range: "Período de tempo"
+  insight_start_range: "Início:"
+  insight_end_range: "Fim:"
+  insight_filter: "Filtar"
   insights_blurb_one:
     one: "<strong>%{period}</strong> seus usuários iniciaram 1 nova interação"
     other: "<strong>%{period}</strong> seus usuários iniciaram <strong>%{count} novas interações</strong>"
@@ -288,6 +301,38 @@ pt-br:
   median_time: "Média de tempo para a primeira resposta"
   add_more_agents: "Adicionar novos agentes"
 
+  # Keyboard Shortcuts
+  shortcut_then: "então"
+  listing_views: "Listar ações de visualização"
+  keyboard_shortcuts: "Atalhos de teclado"
+  show_new_tickets: "Mostrar novos tickets"
+  show_all_tickets: "Mostrar todos os tickets"
+  show_open_tickets: "Mostrar tickets em aberto"
+  show_tickets_assigned_to_you: "Mostrar tickets vínculados a você"
+  show_pending_tickets_assigned_to_you: "Mostrar tickets pendentes vínculados a você"
+  show_closed_tickets: "Mostrar tickets encerrados"
+  search_for_tickets: "Procurar por tickets"
+  viewing_tickets: "Visualizar tickets"
+  select_previous_ticket: "Selecionar ticket anterior"
+  select_next_ticket: "Selecionar próximo ticket"
+  view_selected_ticket: "Visualizer ticket selecionado"
+  jump_to_a_specific_ticket_number: "Ir para ticket de número especifíco"
+  ticket_actions: "Ações de tickets"
+  assign_the_ticket: "Víncular ticket"
+  move_the_ticket: "Mover ticket"
+  expand_the_ticket_thread: "Expandir discussão do ticket"
+  reply_to_the_ticket: "Responder ao ticket"
+  add_an_internal_note: "Adicionar nota interna"
+  change_ticket_status: "Mudar status do ticket"
+  associate_with_a_group: "Associar à um grupo de agentes"
+  ticket_status: "Status do ticket"
+  mark_resolved: "Marcar como resolvido"
+  reopen_ticket: "Reabrir ticket"
+  set_to_new: "Marcar como novo"
+  mark_as_spam: "Marcar como spam"
+  move_to_trash: "Mover ao lixo"
+  ticket_number: "numero do ticket"
+
   # Settings
   agent_settings: "Configurações dos agentes"
 
@@ -299,6 +344,7 @@ pt-br:
   design: "Design"
   international: "Internacionalização"
   widget: "Widget embarcado"
+  integrations: Integrações
 
   notifications_description: "Escolha em que momento deseja ser notificado via e-mail"
   api_description: "Crie e gerencie suas chaves de acesso a API Helpy!"
@@ -310,6 +356,7 @@ pt-br:
   email_description: "Configure o SMTP e a caixa de recebimento de e-mails para seu Helpy."
   cloudinary_description: "Configure o Cloudinary para que seu Helpy usufrua de um adorável sistema de hospedagem de arquivos."
   users_description: "Visualize e adicione novos usuários!"
+  integrations_description: "Configure integrações com aplicativos externos!"
 
   # Notifications Area
   notify_on_private: "Me envie um e-mail quando uma pergunta PRIVADA de cliente for recebida."
@@ -387,6 +434,7 @@ pt-br:
         meta_description: "Meta Descrição"
         front_page: "Página Frontal"
         active: "Ativo"
+        public: "Acesso público"
       doc:
         title: "Título"
         meta_description: Meta Descrição


### PR DESCRIPTION
I added some translation features on Helpy, making Helpy more _international-like_.
More translations key are added on Helpy, but all keys have a default text in English.

Shortcuts now has total translation support.