### PR TITLE
Admin can delete users

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -95,6 +95,16 @@ class Admin::UsersController < Admin::BaseController
     end
   end
 
+  def destroy
+    @user = User.find(params[:id])
+    @user.destroy
+
+    respond_to do |format|
+      format.html { redirect_to admin_users_path }
+      format.js { }
+    end
+  end
+
   def invite
   end
 

--- a/app/controllers/api/v1/users.rb
+++ b/app/controllers/api/v1/users.rb
@@ -171,6 +171,17 @@ module API
           present user, with: Entity::User
         end
 
+        # DELETE A USER
+        desc "Delete a user"
+        params do
+          requires :id, type: Integer, desc: "User ID"
+        end
+        delete ":id", root: :users do
+          user = User.find(permitted_params[:id])
+          user.destroy
+          body false
+        end
+
         # INVITE USER
         desc "Invite one or more users to create an account"
         params do

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,12 +90,12 @@ class User < ActiveRecord::Base
   paginates_per 15
 
   # Relationships
-  has_and_belongs_to_many :roles
-  has_many :topics
-  has_many :posts
-  has_many :votes
-  has_many :docs
-  has_many :api_keys
+
+  has_many :topics, dependent: :delete_all
+  has_many :posts, dependent: :delete_all
+  has_many :votes, dependent: :delete_all
+  has_many :docs, dependent: :delete_all
+  has_many :api_keys, dependent: :delete_all
   has_attachment  :avatar, accept: [:jpg, :png, :gif]
   is_gravtastic
 

--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -23,6 +23,9 @@
       <ul class="dropdown-menu dropdown-menu-right" role="menu">
         <li><%= link_to t(:discussions, default: 'Discussions'), admin_user_path(user), remote: true %></li>
         <li><%= link_to t(:edit_user, default: 'Edit User'), admin_user_path(user, mode: 'edit'), remote: true %></li>
+        <li><%= link_to t(:delete_user, default: 'Delete User'), admin_user_path(user), remote: true,
+                        method: :delete,
+                        data: { confirm: "Are you sure you want to delete #{user.name}?" } if current_user.is_admin? %></li>
       </ul>
     </div>
   </td>

--- a/app/views/admin/users/destroy.js.erb
+++ b/app/views/admin/users/destroy.js.erb
@@ -1,0 +1,1 @@
+$('#user-<%= @user.id %>').remove();

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -160,6 +160,7 @@ ca:
   contact_info: Contacte
   social_info: Social
   edit_user:
+#  delete_user: Delete User
   work_phone: feina
   cell_phone: mòbil
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -160,6 +160,7 @@ de:
   contact_info: Kontakt
   social_info: Soziales
   edit_user: Benutzer bearbeiten
+#  delete_user: Delete User
   work_phone: Arbeit
   cell_phone: Handy
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -163,6 +163,7 @@ en:
   contact_info: Contact
   social_info: Social
   edit_user: Edit User
+  delete_user: Delete User
   work_phone: work
   cell_phone: cell
 

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -160,6 +160,7 @@ es:
   contact_info: Contacto
   social_info: Social
   edit_user:
+#  delete_user: Delete User
   work_phone: trabajo
   cell_phone: móvil
 

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -160,6 +160,7 @@ et:
   contact_info: Kontakt
   social_info: Sotsiaalne
   edit_user:
+#  delete_user: Delete User
   work_phone: töö
   cell_phone: telefon
 

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -160,6 +160,7 @@ fa:
   contact_info: تماس
   social_info: سوشال
   edit_user: ویرایش کاربر
+#  delete_user: Delete User
   work_phone: تلفن دفتر
   cell_phone: موبایل
 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -160,6 +160,7 @@ fr:
   contact_info: Informations de contact
   social_info: Réseaux sociaux
   edit_user:
+#  delete_user: Delete User
   work_phone: téléphone professionnel
   cell_phone: portable
 

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -160,6 +160,7 @@ hi:
   contact_info: संपर्क करें
   social_info: सोशियल
   edit_user: Edit User
+#  delete_user: Delete User
   work_phone: काम
   cell_phone: मोबाइल
 

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -163,6 +163,7 @@ hu:
   contact_info: Kapcsolat
   social_info: Social
   edit_user: Felhasználó szerkesztés
+#  delete_user: Delete User
   work_phone: munka
   cell_phone: mobil
 

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -160,6 +160,7 @@ it:
   contact_info: Contacto
   social_info: Medie Sociale
   edit_user: Modifica utente
+#  delete_user: Delete User
   work_phone: Telefono (Business)
   cell_phone: telefonine
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -160,6 +160,7 @@ ja:
   contact_info: "連絡先"
   social_info: "SNS"
   edit_user:
+#  delete_user: Delete User
   work_phone: "職場の電話番号"
   cell_phone: "携帯電話番号"
 

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -160,6 +160,7 @@ nl:
   contact_info: Contact
   social_info: Social Media
   edit_user: Gebruiker bewerken
+#  delete_user: Delete User
   work_phone: Telefoon (zakelijk)
   cell_phone: Mobiel
 

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -160,6 +160,7 @@ pt:
   contact_info: "Contacto"
   social_info: "Social"
   edit_user: "Editar Utilizador"
+#  delete_user: Delete User
   work_phone: "trabalho"
   cell_phone: "telemóvel"
 

--- a/config/locales/pt_BR.yml
+++ b/config/locales/pt_BR.yml
@@ -183,6 +183,7 @@ pt-br:
   contact_info: "Contato"
   social_info: "Social"
   edit_user: "Editar Usuário"
+#  delete_user: Delete User
   work_phone: "trabalho"
   cell_phone: "celular"
 

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -164,6 +164,7 @@ ru:
   contact_info: Контакт
   social_info: Социальные сети
   edit_user: Редактировать пользователя
+#  delete_user: Delete User
   work_phone: номер рабочего телефона
   cell_phone: номер мобильного телефона
 

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -156,6 +156,7 @@ sv:
   contact_info: Kontakt
   social_info: Sociala medier
   edit_user: Redigera användarkonto
+#  delete_user: Delete User
   work_phone: arbete
   cell_phone: mobil
 

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -160,6 +160,7 @@ tr:
   contact_info: İletişim
   social_info: Sosyal
   edit_user: Kullanıcıyı Düzenle
+#  delete_user: Delete User
   work_phone: İş
   cell_phone: Cep
 

--- a/config/locales/zh_CN.yml
+++ b/config/locales/zh_CN.yml
@@ -160,6 +160,7 @@ zh-cn:
   contact_info: 联络
   social_info: 社交网站
   edit_user: 修改使用者
+#  delete_user: Delete User
   work_phone: 公司
   cell_phone: 行动电话
 

--- a/config/locales/zh_TW.yml
+++ b/config/locales/zh_TW.yml
@@ -160,6 +160,7 @@ zh-tw:
   contact_info: 聯絡
   social_info: 社交網站
   edit_user: 修改使用者
+#  delete_user: Delete User
   work_phone: 公司
   cell_phone: 行動電話
 

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -90,6 +90,23 @@ class Admin::UsersControllerTest < ActionController::TestCase
       xhr :get, :edit, { id: 2 }
       # assert_response :success
     end
+
+    test "an #{admin} should be able to destroy a user" do
+      sign_in users(admin.to_sym)
+      assert_difference "User.count", -1 do
+        xhr :delete, :destroy, id: 3, locale: :en
+      end
+      assert_response :success
+    end
+  end
+
+  %w(user editor).each do |unauthorized|
+    test "an #{unauthorized} should NOT be able to destroy a user" do
+      sign_in users(unauthorized.to_sym)
+      assert_difference("User.count", 0) do
+        xhr :delete, :destroy, id: 3, locale: :en
+      end
+    end
   end
 
   test "an admin should be able to update a user and make them an admin" do

--- a/test/controllers/api/v1/users_test.rb
+++ b/test/controllers/api/v1/users_test.rb
@@ -170,4 +170,11 @@ class API::V1::UsersTest < ActiveSupport::TestCase
     # Ensure the invited user has a token
     assert_not_equal invited_user.invitation_token, nil
   end
+
+  test "an API user can delete users" do
+    user = User.create!(name: "foo", email: "foo@bar.com", password: "password")
+    delete "/api/v1/users/#{user.id}.json", @default_params
+
+    assert_equal 204, last_response.status
+  end
 end


### PR DESCRIPTION
This feature allows admins to delete users one at a time. Let me know if you want to batch delete them. Deleting a user also deletes all associated objects (i.e., topics, posts, votes, docs, and api keys). For issue: #457 