### PR TITLE
Add a groups management UI

### DIFF
--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -17,7 +17,8 @@ class Admin::GroupsController < Admin::BaseController
   before_action :verify_admin
   
   def index
-    @teams = ActsAsTaggableOn::Tag.all
+    team_tag_ids = ActsAsTaggableOn::Tagging.all.where(context: "teams").includes(:tag).map{|tagging| tagging.tag.id }.uniq
+    @teams = ActsAsTaggableOn::Tag.where("id IN (?)", team_tag_ids)
   end
 
   def new
@@ -47,6 +48,7 @@ class Admin::GroupsController < Admin::BaseController
 
   def destroy
     @team = ActsAsTaggableOn::Tag.find(params[:id])
+    @team.taggings.destroy_all
     @team.destroy
     redirect_to admin_groups_path
   end

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -39,7 +39,8 @@ class Admin::GroupsController < Admin::BaseController
   end
 
   def create
-    if ActsAsTaggableOn::Tag.create(group_params)
+    tag = ActsAsTaggableOn::Tag.create(group_params)
+    if ActsAsTaggableOn::Tagging.create(tag_id: tag.id, context: "teams") 
       redirect_to admin_groups_path
     else
       render new_admin_group_path

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -12,10 +12,10 @@
 class Admin::GroupsController < Admin::BaseController
 
   before_action :set_user
-
-  # Restrict API token generation to admin only for now
   before_action :verify_admin
-  
+
+  layout 'admin-settings'
+
   def index
     team_tag_ids = ActsAsTaggableOn::Tagging.all.where(context: "teams").includes(:tag).map{|tagging| tagging.tag.id }.uniq
     @teams = ActsAsTaggableOn::Tag.where("id IN (?)", team_tag_ids)
@@ -34,13 +34,13 @@ class Admin::GroupsController < Admin::BaseController
     if @team.update_attributes(group_params)
       redirect_to admin_groups_path
     else
-      render edit_admin_groups_path(@team) 
+      render edit_admin_groups_path(@team)
     end
   end
 
   def create
     tag = ActsAsTaggableOn::Tag.create(group_params)
-    if ActsAsTaggableOn::Tagging.create(tag_id: tag.id, context: "teams") 
+    if ActsAsTaggableOn::Tagging.create(tag_id: tag.id, context: "teams")
       redirect_to admin_groups_path
     else
       render new_admin_group_path

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -1,0 +1,71 @@
+# == Schema Information
+#
+# Table name: tags
+#
+#  id                     :integer          not null, primary key
+#  name                   :string
+#  show_on_helpcenter     :boolean
+#  show_on_admin          :boolean
+#   show_on_dashboard     :boolean
+#
+
+class Admin::GroupsController < Admin::BaseController
+
+  before_action :set_user
+
+  # Restrict API token generation to admin only for now
+  before_action :verify_admin
+  before_action :get_all_teams
+
+  def index
+    @teams = ActsAsTaggableOn::Tag.all
+  end
+
+  def edit
+    @team = ActsAsTaggableOn::Tag.find(params[:id])
+  end
+
+  def update
+    @team = ActsAsTaggableOn::Tag.find(params[:id])
+    if @team.update_columns(params[:acts_as_taggable_on_tag])
+      redirect_to admin_groups_path
+    else
+      render edit_admin_groups_path(@team) 
+    end
+  end
+
+  def create
+    @api_key = ApiKey.new(api_key_params)
+    # @api_key.user_id = @user.id
+    if @api_key.save
+      render
+    end
+  end
+
+  def destroy
+    @api_key = @user.api_keys.where(id: params[:id]).first
+    @api_key.update! date_expired: Time.current
+  end
+
+  protected
+
+  def set_user
+    # An admin should be able to view others API keys
+    if current_user.is_admin?
+      @user = params[:api_key].present? ? User.find(params[:api_key][:user_id]) : current_user
+    else # An agent should be able to view their own API keys only
+      @user = current_user
+    end
+  end
+
+  private
+
+  def api_key_params
+    params.require(:api_key).permit(
+    :name,
+    :user_id
+  )
+  end
+
+
+end

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -34,7 +34,7 @@ class Admin::GroupsController < Admin::BaseController
     if @team.update_attributes(group_params)
       redirect_to admin_groups_path
     else
-      render edit_admin_groups_path(@team)
+      render :edit
     end
   end
 

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -15,10 +15,13 @@ class Admin::GroupsController < Admin::BaseController
 
   # Restrict API token generation to admin only for now
   before_action :verify_admin
-  before_action :get_all_teams
-
+  
   def index
     @teams = ActsAsTaggableOn::Tag.all
+  end
+
+  def new
+    @team = ActsAsTaggableOn::Tag.new
   end
 
   def edit
@@ -27,7 +30,7 @@ class Admin::GroupsController < Admin::BaseController
 
   def update
     @team = ActsAsTaggableOn::Tag.find(params[:id])
-    if @team.update_columns(params[:acts_as_taggable_on_tag])
+    if @team.update_attributes(group_params)
       redirect_to admin_groups_path
     else
       render edit_admin_groups_path(@team) 
@@ -35,16 +38,17 @@ class Admin::GroupsController < Admin::BaseController
   end
 
   def create
-    @api_key = ApiKey.new(api_key_params)
-    # @api_key.user_id = @user.id
-    if @api_key.save
-      render
+    if ActsAsTaggableOn::Tag.create(group_params)
+      redirect_to admin_groups_path
+    else
+      render new_admin_group_path
     end
   end
 
   def destroy
-    @api_key = @user.api_keys.where(id: params[:id]).first
-    @api_key.update! date_expired: Time.current
+    @team = ActsAsTaggableOn::Tag.find(params[:id])
+    @team.destroy
+    redirect_to admin_groups_path
   end
 
   protected
@@ -60,12 +64,12 @@ class Admin::GroupsController < Admin::BaseController
 
   private
 
-  def api_key_params
-    params.require(:api_key).permit(
-    :name,
-    :user_id
-  )
+  def group_params
+    params.require(:acts_as_taggable_on_tag).permit(
+      :name,
+      :show_on_helpcenter,
+      :show_on_admin,
+      :show_on_dashboard
+    )
   end
-
-
 end

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -49,7 +49,7 @@ class Admin::GroupsController < Admin::BaseController
 
   def destroy
     @team = ActsAsTaggableOn::Tag.find(params[:id])
-    @team.taggings.destroy_all
+    @team.taggings.destroy_all if @team.taggings.present?
     @team.destroy
     redirect_to admin_groups_path
   end

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -70,6 +70,8 @@ class Admin::GroupsController < Admin::BaseController
   def group_params
     params.require(:acts_as_taggable_on_tag).permit(
       :name,
+      :description,
+      :color,
       :show_on_helpcenter,
       :show_on_admin,
       :show_on_dashboard

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -192,7 +192,7 @@ module AdminHelper
     end
   end
 
-  def all_teams
+  def admin_teams
     ActsAsTaggableOn::Tagging.all.where(context: "teams").includes(:tag).where("context = 'teams' and tags.show_on_admin = ?", 'true').references(:tags).map{|tagging| tagging.tag.name.capitalize }.uniq
   end
 

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -192,4 +192,8 @@ module AdminHelper
     end
   end
 
+  def all_teams
+    ActsAsTaggableOn::Tagging.all.where(context: "teams").includes(:tag).where("context = 'teams' and tags.show_on_admin = ?", 'true').references(:tags).map{|tagging| tagging.tag.name.capitalize }.uniq
+  end
+
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -90,7 +90,7 @@ module ApplicationHelper
   def tag_listing(tags, tagging_type = "message")
     return unless teams? || tagging_type == "doc"
     tags.each do |tag|
-      concat content_tag(:span, tag, class: "label label-#{tagging_type}-tagging label-#{tag.first.downcase} #{'pull-right' if tagging_type == 'message'}")
+      concat content_tag(:span, tag, style: badge_color_from_tag(tag),class: "label label-#{tagging_type}-tagging label-#{tag.first.downcase} #{'pull-right' if tagging_type == 'message'}")
     end
   end
 

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -83,5 +83,8 @@ module TopicsHelper
     end
   end
 
+  def all_teams
+    ActsAsTaggableOn::Tagging.all.where(context: "teams").includes(:tag).where("context = 'teams' and tags.show_on_dashboard = ?", 'true').references(:tags).map{|tagging| tagging.tag.name.capitalize }.uniq
+  end
 
 end

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -83,8 +83,25 @@ module TopicsHelper
     end
   end
 
+  # Lookup the user set color, if it exists
+  def badge_color_from_tag(tag_name)
+    tagging = ActsAsTaggableOn::Tag.where('lower(name) = ?', tag_name.downcase).first
+    tagging.present? && tagging.color.present? ? 'background-color: ' + tagging.color : ''
+  end
+
+  def badge_color_from_topic(topic)
+    return '' if topic.team_list.blank?
+
+    tagging = ActsAsTaggableOn::Tag.where('lower(name) = ?', topic.team_list.first.downcase)
+    return badge_color_from_tag(tagging.first.name) unless tagging.nil?
+  end
+
   def all_teams
     ActsAsTaggableOn::Tagging.all.where(context: "teams").includes(:tag).where("context = 'teams' and tags.show_on_helpcenter = ?", 'true').references(:tags).map{|tagging| tagging.tag.name.capitalize }.uniq
+  end
+
+  def color_sample(tag_name)
+    content_tag(:div, '', style: badge_color_from_tag(tag_name), class: 'color-sample label-' + tag_name.first.downcase) + content_tag(:div, tag_name.try(:titleize))
   end
 
 end

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -84,7 +84,7 @@ module TopicsHelper
   end
 
   def all_teams
-    ActsAsTaggableOn::Tagging.all.where(context: "teams").includes(:tag).where("context = 'teams' and tags.show_on_dashboard = ?", 'true').references(:tags).map{|tagging| tagging.tag.name.capitalize }.uniq
+    ActsAsTaggableOn::Tagging.all.where(context: "teams").includes(:tag).where("context = 'teams' and tags.show_on_helpcenter = ?", 'true').references(:tags).map{|tagging| tagging.tag.name.capitalize }.uniq
   end
 
 end

--- a/app/views/admin/groups/_form.html.erb
+++ b/app/views/admin/groups/_form.html.erb
@@ -1,10 +1,13 @@
 
   <div class="settings-section group">
-    <%= f.text_field 'name', label: t(:tag_name, default: "Group Name"), placeholder: t(:tag_name, default: 'Group Name') %>
-    <%= f.check_box 'show_on_helpcenter', { checked: @team.show_on_helpcenter, label: t('show_on_helpcenter', default: "Show on helpcenter"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
-    <%= f.check_box 'show_on_admin', { checked: @team.show_on_admin, label: t('show_on_admin', default: "Show on admin"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
-    <%= f.check_box 'show_on_dashboard', { checked: @team.show_on_dashboard, label: t('show_on_dashboard', default: "Show on dashboard"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
+    <%= f.input 'name', label: t(:tag_name, default: "Group Name"), placeholder: t(:tag_name, default: 'Group Name') %>
+    <%= f.input 'description', label: t('description', default: "Description") %>
+    <%= f.input 'color', inline_label: t('color', default: "Color"), input_html: { class: 'pick-a-color' } %>
+    <br/>
+    <%= f.input 'show_on_helpcenter', checked: @team.show_on_helpcenter, label: t('show_on_helpcenter', default: "Show on helpcenter"), label_html: { class: 'full-width' }, input_html: { class: 'bs-toggle', data: { size: 'mini' } } %>
+    <%= f.input 'show_on_admin', checked: @team.show_on_admin, label: t('show_on_admin', default: "Show on admin"), label_html: { class: 'full-width' }, input_html: { class: 'bs-toggle', data: { size: 'mini' } } %>
+    <%#= f.check_box 'show_on_dashboard', checked: @team.show_on_dashboard, label: t('show_on_dashboard', default: "Show on dashboard"), label_html: { class: 'full-width' }, input_html: { class: 'bs-toggle', data: { size: 'mini' } }%>
   </div>
   <div class="submit-section">
-    <%= f.submit "Save Settings", class: 'btn btn-warning' %>
+    <%= f.button :submit, "Save Settings", class: 'btn btn-warning' %>
   </div>

--- a/app/views/admin/groups/_form.html.erb
+++ b/app/views/admin/groups/_form.html.erb
@@ -1,0 +1,10 @@
+
+  <div class="settings-section group">
+    <%= f.text_field 'name', label: t(:tag_name, default: "Group Name"), placeholder: t(:tag_name, default: 'Group Name') %>
+    <%= f.check_box 'show_on_helpcenter', { checked: @team.show_on_helpcenter, label: t('show_on_helpcenter', default: "Show on helpcenter"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
+    <%= f.check_box 'show_on_admin', { checked: @team.show_on_admin, label: t('show_on_admin', default: "Show on admin"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
+    <%= f.check_box 'show_on_dashboard', { checked: @team.show_on_dashboard, label: t('show_on_dashboard', default: "Show on dashboard"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
+  </div>
+  <div class="submit-section">
+    <%= f.submit "Save Settings", class: 'btn btn-warning' %>
+  </div>

--- a/app/views/admin/groups/_group.html.erb
+++ b/app/views/admin/groups/_group.html.erb
@@ -1,0 +1,15 @@
+<tr id="group-<%= group.id %>" class="group">
+  <td class="tag-name">
+    <h4><%= content_tag('span', group.name) %></h4>
+  </td>
+  
+  <td class="text-right">
+    <div class="btn-group">
+      <span id="row-<%= group.id %>" data-toggle="dropdown" aria-expanded="false" class='btn dropdown-toggle glyphicon glyphicon-align-justify'></span>
+      <ul class="dropdown-menu dropdown-menu-right" role="menu">
+        <li><%= link_to t(:edit, default: 'Edit'), edit_admin_group_path(group.id) %></li>
+        <li><%#= link_to t(:edit_user, default: 'Edit User'), admin_user_path(user, mode: 'edit'), remote: true %></li>
+      </ul>
+    </div>
+  </td>
+</tr>

--- a/app/views/admin/groups/_group.html.erb
+++ b/app/views/admin/groups/_group.html.erb
@@ -1,10 +1,10 @@
   <div class="row group vcenter border-bottom" id="group-<%= group.id %>">
-    <div class="text-left col-md-6">
+    <div class="text-left col-md-6 col-sm-6 col-xs-6">
       <div class="color-sample" style="background-color: <%= group.color %>"></div>
       <span class="more-important"><%= content_tag('span', group.name) %></span>
       <span class="less-important"><%= group.description %></span>
     </div>
-    <div class="text-right col-md-6">
+    <div class="text-right col-md-6 col-sm-6 col-xs-6">
       <div class="btn-group">
         <span id="row-<%= group.id %>" data-toggle="dropdown" aria-expanded="false" class='btn dropdown-toggle glyphicon glyphicon-align-justify'></span>
         <ul class="dropdown-menu dropdown-menu-right" role="menu">

--- a/app/views/admin/groups/_group.html.erb
+++ b/app/views/admin/groups/_group.html.erb
@@ -1,15 +1,16 @@
-<tr id="group-<%= group.id %>" class="group">
-  <td class="tag-name">
-    <h4><%= content_tag('span', group.name) %></h4>
-  </td>
-  
-  <td class="text-right">
-    <div class="btn-group">
-      <span id="row-<%= group.id %>" data-toggle="dropdown" aria-expanded="false" class='btn dropdown-toggle glyphicon glyphicon-align-justify'></span>
-      <ul class="dropdown-menu dropdown-menu-right" role="menu">
-        <li><%= link_to t(:edit, default: 'Edit'), edit_admin_group_path(group.id) %></li>
-        <li><%= link_to t(:delete, default: 'Delete'), admin_group_path(group.id), method: :delete, :data => {:confirm => 'Do you really want to delete this group?'} %></li>
-      </ul>
+  <div class="row group vcenter border-bottom" id="group-<%= group.id %>">
+    <div class="text-left col-md-6">
+      <div class="color-sample" style="background-color: <%= group.color %>"></div>
+      <span class="more-important"><%= content_tag('span', group.name) %></span>
+      <span class="less-important"><%= group.description %></span>
     </div>
-  </td>
-</tr>
+    <div class="text-right col-md-6">
+      <div class="btn-group">
+        <span id="row-<%= group.id %>" data-toggle="dropdown" aria-expanded="false" class='btn dropdown-toggle glyphicon glyphicon-align-justify'></span>
+        <ul class="dropdown-menu dropdown-menu-right" role="menu">
+          <li><%= link_to t(:edit, default: 'Edit'), edit_admin_group_path(group.id) %></li>
+          <li><%= link_to t(:delete, default: 'Delete'), admin_group_path(group.id), method: :delete, :data => {:confirm => 'Do you really want to delete this group?'} %></li>
+        </ul>
+      </div>
+    </div>
+  </div>

--- a/app/views/admin/groups/_group.html.erb
+++ b/app/views/admin/groups/_group.html.erb
@@ -8,7 +8,7 @@
       <span id="row-<%= group.id %>" data-toggle="dropdown" aria-expanded="false" class='btn dropdown-toggle glyphicon glyphicon-align-justify'></span>
       <ul class="dropdown-menu dropdown-menu-right" role="menu">
         <li><%= link_to t(:edit, default: 'Edit'), edit_admin_group_path(group.id) %></li>
-        <li><%#= link_to t(:edit_user, default: 'Edit User'), admin_user_path(user, mode: 'edit'), remote: true %></li>
+        <li><%= link_to t(:delete, default: 'Delete'), admin_group_path(group.id), method: :delete, :data => {:confirm => 'Do you really want to delete this group?'} %></li>
       </ul>
     </div>
   </td>

--- a/app/views/admin/groups/_groups.html.erb
+++ b/app/views/admin/groups/_groups.html.erb
@@ -1,0 +1,7 @@
+<table id="groups">
+  <col width="98%">
+  <col width="2%">
+
+  <%= render partial: 'admin/groups/group', collection: @teams if @teams %>
+</table>
+

--- a/app/views/admin/groups/_groups.html.erb
+++ b/app/views/admin/groups/_groups.html.erb
@@ -1,7 +1,0 @@
-<table id="groups">
-  <col width="98%">
-  <col width="2%">
-
-  <%= render partial: 'admin/groups/group', collection: @teams if @teams %>
-</table>
-

--- a/app/views/admin/groups/edit.html.erb
+++ b/app/views/admin/groups/edit.html.erb
@@ -1,14 +1,16 @@
 <% title "#{admin_title} #{t('group', default: "Group")}" %>
 
-<div class="admin-header">
-  <h2 id="setting-header">
-    <%= "#{@team.name} #{t('tag_group', default: 'Group')}" %>
-  </h2>
-</div>
-<div class="settings-panel row">
-  <div class="col-md-9 col-sm-8 col-xs-10">
-    <%= bootstrap_form_for @team, url: admin_group_path(@team), method: 'put', remote: false do |f| %>
-      <%= render "form", f: f  %>
-    <% end %>  
+<% content_for :settings do %>
+  <div class="admin-header">
+    <h2 id="setting-header">
+      <%= "#{@team.name} #{t('tag_group', default: 'Group')}" %>
+    </h2>
   </div>
-</div>
+  <div class="settings-panel row">
+    <div class="col-md-9 col-sm-8 col-xs-10">
+      <%= bootstrap_form_for @team, url: admin_group_path(@team), method: 'put', remote: false do |f| %>
+        <%= render "form", f: f  %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/groups/edit.html.erb
+++ b/app/views/admin/groups/edit.html.erb
@@ -7,8 +7,8 @@
     </h2>
   </div>
   <div class="settings-panel row">
-    <div class="col-md-9 col-sm-8 col-xs-10">
-      <%= bootstrap_form_for @team, url: admin_group_path(@team), method: 'put', remote: false do |f| %>
+    <div class="col-md-12 col-sm-12 col-xs-12">
+      <%= simple_form_for @team, url: admin_group_path(@team), method: 'put', remote: false do |f| %>
         <%= render "form", f: f  %>
       <% end %>
     </div>

--- a/app/views/admin/groups/edit.html.erb
+++ b/app/views/admin/groups/edit.html.erb
@@ -1,0 +1,22 @@
+<% title "#{admin_title} #{t('group', default: "Group")}" %>
+
+<div class="admin-header">
+  <h2 id="setting-header">
+    <%= "#{@team.name} #{t('tag_group', default: 'Group')}" %>
+  </h2>
+</div>
+<div class="settings-panel row">
+  <div class="col-md-9 col-sm-8 col-xs-10">
+    <%= bootstrap_form_for @team, url: admin_group_path(@team), method: 'put', remote: false do |f| %>
+      <div class="settings-section group">
+        <%= f.text_field 'name', label: t(:tag_name, default: "Group Name"), placeholder: t(:tag_name, default: 'Group Name') %>
+        <%= f.check_box 'show_on_helpcenter', { checked: @team.show_on_helpcenter, label: t('show_on_helpcenter', default: "Show on helpcenter"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
+        <%= f.check_box 'show_on_admin', { checked: @team.show_on_admin, label: t('show_on_admin', default: "Show on admin"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
+        <%= f.check_box 'show_on_dashboard', { checked: @team.show_on_dashboard, label: t('show_on_dashboard', default: "Show on dashboard"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
+      </div>
+      <div class="submit-section">
+        <%= f.submit "Save Settings", class: 'btn btn-warning' %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/groups/index.html.erb
+++ b/app/views/admin/groups/index.html.erb
@@ -1,14 +1,16 @@
 <% title "#{admin_title} #{t('groups', default: "Groups")}" %>
 
-<div class="admin-header">
-  <h2 id="setting-header">
-    <%= t('groups', default: 'Groups') %>
-    <span class="pull-right">
-	    <%= link_to t(:add_new_group, default: "Add New Group"), new_admin_group_path, remote: false, class: 'btn btn-primary' if current_user.is_admin? %>
-	  </span>
-  </h2>
-</div>
+<% content_for :settings do %>
+  <div class="admin-header">
+    <h2 id="setting-header">
+      <%= t('groups', default: 'Groups') %>
+      <span class="pull-right">
+  	    <%= link_to t(:add_new_group, default: "Add New Group"), new_admin_group_path, remote: false, class: 'btn btn-primary' if current_user.is_admin? %>
+  	  </span>
+    </h2>
+  </div>
 
-<div id="groups">
-  <%= render partial: 'admin/groups/groups' %>
-</div>
+  <div id="groups">
+    <%= render partial: 'admin/groups/groups' %>
+  </div>
+<% end %>

--- a/app/views/admin/groups/index.html.erb
+++ b/app/views/admin/groups/index.html.erb
@@ -1,0 +1,14 @@
+<% title "#{admin_title} #{t('groups', default: "Groups")}" %>
+
+<div class="admin-header">
+  <h2 id="setting-header">
+    <%= t('groups', default: 'Groups') %>
+    <span class="pull-right">
+	    <%#= link_to t(:add_new_group, default: "Add New Group"), admin_invite_path, remote: false, class: 'btn btn-primary' if current_user.is_admin? %>
+	  </span>
+  </h2>
+</div>
+
+<div id="groups">
+  <%= render partial: 'admin/groups/groups' %>
+</div>

--- a/app/views/admin/groups/index.html.erb
+++ b/app/views/admin/groups/index.html.erb
@@ -4,7 +4,7 @@
   <h2 id="setting-header">
     <%= t('groups', default: 'Groups') %>
     <span class="pull-right">
-	    <%#= link_to t(:add_new_group, default: "Add New Group"), admin_invite_path, remote: false, class: 'btn btn-primary' if current_user.is_admin? %>
+	    <%= link_to t(:add_new_group, default: "Add New Group"), new_admin_group_path, remote: false, class: 'btn btn-primary' if current_user.is_admin? %>
 	  </span>
   </h2>
 </div>

--- a/app/views/admin/groups/index.html.erb
+++ b/app/views/admin/groups/index.html.erb
@@ -1,6 +1,13 @@
 <% title "#{admin_title} #{t('groups', default: "Groups")}" %>
 
 <% content_for :settings do %>
+
+  <style>
+    .group {
+      height: 60px;
+    }
+  </style>
+
   <div class="admin-header">
     <h2 id="setting-header">
       <%= t('groups', default: 'Groups') %>
@@ -10,7 +17,14 @@
     </h2>
   </div>
 
-  <div id="groups">
-    <%= render partial: 'admin/groups/groups' %>
+  <div class="settings-section">
+    <div class="row group-header vcenter border-bottom">
+      <div class="pull-left tiny-header col-md-12">
+        Group
+      </div>
+    </div>
+
+    <%= render partial: 'admin/groups/group', collection: @teams if @teams %>
   </div>
+
 <% end %>

--- a/app/views/admin/groups/new.html.erb
+++ b/app/views/admin/groups/new.html.erb
@@ -7,8 +7,8 @@
     </h2>
   </div>
   <div class="settings-panel row">
-    <div class="col-md-9 col-sm-8 col-xs-10">
-      <%= bootstrap_form_for @team, url: admin_groups_path, method: 'post', remote: false do |f| %>
+    <div class="col-md-12 col-sm-12 col-xs-12">
+      <%= simple_form_for @team, url: admin_groups_path, method: 'post', remote: false do |f| %>
         <%= render "form", f: f  %>
       <% end %>
     </div>

--- a/app/views/admin/groups/new.html.erb
+++ b/app/views/admin/groups/new.html.erb
@@ -2,12 +2,12 @@
 
 <div class="admin-header">
   <h2 id="setting-header">
-    <%= "#{@team.name} #{t('tag_group', default: 'Group')}" %>
+    <%= "New #{t('tag_group', default: 'Group')}" %>
   </h2>
 </div>
 <div class="settings-panel row">
   <div class="col-md-9 col-sm-8 col-xs-10">
-    <%= bootstrap_form_for @team, url: admin_group_path(@team), method: 'put', remote: false do |f| %>
+    <%= bootstrap_form_for @team, url: admin_groups_path, method: 'post', remote: false do |f| %>
       <%= render "form", f: f  %>
     <% end %>  
   </div>

--- a/app/views/admin/groups/new.html.erb
+++ b/app/views/admin/groups/new.html.erb
@@ -1,14 +1,16 @@
 <% title "#{admin_title} #{t('group', default: "Group")}" %>
 
-<div class="admin-header">
-  <h2 id="setting-header">
-    <%= "New #{t('tag_group', default: 'Group')}" %>
-  </h2>
-</div>
-<div class="settings-panel row">
-  <div class="col-md-9 col-sm-8 col-xs-10">
-    <%= bootstrap_form_for @team, url: admin_groups_path, method: 'post', remote: false do |f| %>
-      <%= render "form", f: f  %>
-    <% end %>  
+<% content_for :settings do %>
+  <div class="admin-header">
+    <h2 id="setting-header">
+      <%= "New #{t('tag_group', default: 'Group')}" %>
+    </h2>
   </div>
-</div>
+  <div class="settings-panel row">
+    <div class="col-md-9 col-sm-8 col-xs-10">
+      <%= bootstrap_form_for @team, url: admin_groups_path, method: 'post', remote: false do |f| %>
+        <%= render "form", f: f  %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -19,7 +19,7 @@
         <%= settings_item('glyphicon glyphicon-envelope', "email", t('email_description', default: "Set up SMTP and Inbound email for your Helpy."), admin_email_settings_path) %>
         <%= settings_item('fa fa-cogs', "integrations", t('integrations_description', default: "Configure integrations with external services."), admin_integration_settings_path) %>
         <%= settings_item('glyphicon glyphicon-user', "users", t('users_description', default: "View and Add Users"), admin_users_path) %>
-        <%= settings_item('glyphicon glyphicon-tags', t('team_group', default: "Group"),
+        <%= settings_item('glyphicon glyphicon-tags', t('team_group', default: "Groups"),
           t('group_description', default: "Edit, Delete, Create team list."), admin_groups_path) %>
       </div>
     </div>

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -19,6 +19,8 @@
         <%= settings_item('glyphicon glyphicon-envelope', "email", t('email_description', default: "Set up SMTP and Inbound email for your Helpy."), admin_email_settings_path) %>
         <%= settings_item('fa fa-cogs', "integrations", t('integrations_description', default: "Configure integrations with external services."), admin_integration_settings_path) %>
         <%= settings_item('glyphicon glyphicon-user', "users", t('users_description', default: "View and Add Users"), admin_users_path) %>
+        <%= settings_item('glyphicon glyphicon-tags', t('team_group', default: "Group"),
+          t('group_description', default: "Edit, Delete, Create team list."), admin_groups_path) %>
       </div>
     </div>
   </div>

--- a/app/views/admin/settings/notifications.html.erb
+++ b/app/views/admin/settings/notifications.html.erb
@@ -2,24 +2,25 @@
 
 <% content_for :settings do %>
 
-<div class="admin-header">
-  <h2 id="setting-header">
-    <%= t('notifications', default: 'Notifications') %>
-  </h2>
-</div>
-<div class="settings-panel row">
-  <div class="col-md-9 col-sm-8 col-xs-10">
-    <%= bootstrap_form_tag url: admin_update_notifications_path, method: 'put', remote: false do |f| %>
-      <div class="settings-section notifications" data-hook="admin_settings_notifications">
-        <%= f.check_box 'notify_on_private', { checked: current_user.notify_on_private?, label: t('notify_on_private', default: "Email me when a private customer question has been received"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
-        <%= f.check_box 'notify_on_public', { checked: current_user.notify_on_public?, label: t('notify_on_public', default: "Email me when a public customer question has been posted"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
-        <%= f.check_box 'notify_on_reply', { checked: current_user.notify_on_reply?, label: t('notify_on_reply', default: "Email me when a new reply to a private discussion has been received"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
-      </div>
-      <div class="submit-section">
-        <%= f.submit "Save Settings", class: 'btn btn-warning' %>
-      </div>
-    <% end %>
+  <div class="admin-header">
+    <h2 id="setting-header">
+      <%= t('notifications', default: 'Notifications') %>
+    </h2>
   </div>
-</div>
+  
+  <div class="settings-panel row">
+    <div class="col-md-9 col-sm-8 col-xs-10">
+      <%= bootstrap_form_tag url: admin_update_notifications_path, method: 'put', remote: false do |f| %>
+        <div class="settings-section notifications" data-hook="admin_settings_notifications">
+          <%= f.check_box 'notify_on_private', { checked: current_user.notify_on_private?, label: t('notify_on_private', default: "Email me when a private customer question has been received"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
+          <%= f.check_box 'notify_on_public', { checked: current_user.notify_on_public?, label: t('notify_on_public', default: "Email me when a public customer question has been posted"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
+          <%= f.check_box 'notify_on_reply', { checked: current_user.notify_on_reply?, label: t('notify_on_reply', default: "Email me when a new reply to a private discussion has been received"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
+        </div>
+        <div class="submit-section">
+          <%= f.submit "Save Settings", class: 'btn btn-warning' %>
+        </div>
+      <% end %>
+    </div>
+  </div>
 
 <% end %>

--- a/app/views/admin/topics/_new_ticket.html.erb
+++ b/app/views/admin/topics/_new_ticket.html.erb
@@ -11,7 +11,8 @@
     <%= u.input :home_phone, class: 'disable-empty', label: "Phone" %>
     <%= u.input :email, class: 'disable-empty', label: "Email (#{link_to 'generate temporary', '#', class: 'generate-temp'})".html_safe %>
   <% end %>
-  <% if teams = all_teams %>
+
+  <% if teams = admin_teams %>
     <%= f.input(:team_list, collection: teams, :label => t(:assign_to), locale: I18n.locale, prompt: "", style: "display:none;") if teams? and teams.count > 0 %>
   <% end %>
   <%= f.simple_fields_for @topic.posts.new do |i| %>

--- a/app/views/admin/topics/_new_ticket.html.erb
+++ b/app/views/admin/topics/_new_ticket.html.erb
@@ -11,7 +11,9 @@
     <%= u.input :home_phone, class: 'disable-empty', label: "Phone" %>
     <%= u.input :email, class: 'disable-empty', label: "Email (#{link_to 'generate temporary', '#', class: 'generate-temp'})".html_safe %>
   <% end %>
-  <%= f.input(:team_list, collection: @all_teams, :label => t(:assign_to), locale: I18n.locale, prompt: "", style: "display:none;") if teams? and @all_teams.count > 0 %>
+  <% if teams = all_teams %>
+    <%= f.input(:team_list, collection: teams, :label => t(:assign_to), locale: I18n.locale, prompt: "", style: "display:none;") if teams? and teams.count > 0 %>
+  <% end %>
   <%= f.simple_fields_for @topic.posts.new do |i| %>
     <%= i.input :body, input_html: { rows: 8, cols: 60, class: 'disable-empty form-control' }, label: false, validate: { presence: true } -%>
     <% if !cloudinary_enabled? %>

--- a/app/views/admin/topics/_topic_options.html.erb
+++ b/app/views/admin/topics/_topic_options.html.erb
@@ -46,7 +46,7 @@
   <% if teams? %>
     <span class="status btn-group left-col-dropdown">
       <button class="dropdown-toggle ticket-control" data-toggle="dropdown" aria-expanded="false">
-        <%= content_tag(:span, class: "btn status-label-button group-to label label-#{@topic.team_list.present? ? @topic.team_list.first.first.downcase : 'default'}") do %>
+        <%= content_tag(:span, style: badge_color_from_topic(@topic), class: "btn status-label-button group-to label label-#{@topic.team_list.present? ? @topic.team_list.first.first.downcase : 'default'}") do %>
           <%= @topic.team_list.first.try(:upcase) || t(:no_team_assigned, default: 'Assign to group') %>
           <%= icon('caret-down') + ' ' %>
         <% end %>
@@ -55,7 +55,7 @@
         <% @all_teams.to_a.each do |team| %>
           <li class='team-item'>
             <% unless @topic.current_status == "closed" %>
-              <%= link_to("#{content_tag(:div, '', class: 'color-sample label-' + team.first.downcase)} #{content_tag :div, team.try(:titleize)}".html_safe, admin_assign_team_path(topic_ids: { "":@topic.id }, team: team), :remote => true) %>
+              <%= link_to(color_sample(team), admin_assign_team_path(topic_ids: { "":@topic.id }, team: team), :remote => true) %>
             <% end %>
           </li>
         <% end %>

--- a/app/views/layouts/_admin_header.html.erb
+++ b/app/views/layouts/_admin_header.html.erb
@@ -24,7 +24,6 @@
           <%= content_tag(:li, link_to(t(:discussions, default: "Discussions"), admin_topics_path)) if (forums? || tickets?) && current_user.is_agent? %>
           <%= content_tag(:li, link_to(t(:team, default: 'Team'), admin_stats_path(interval: 7))) if tickets? && current_user.is_admin? %>
           <%= helpcenter_menu if (knowledgebase? || forums?) && current_user.is_agent? %>
-          <%= content_tag(:li, link_to(t(:content, default: "Content"), admin_categories_path), class:'kblink') if knowledgebase? && current_user.role == 'editor' %>
           <%= content_tag(:li, link_to(t(:app_store, default: "App Store"), "http://helpy.io/store/"), class: "hidden-sm hidden-xs") if current_user.is_agent? %>
           <%= content_tag(:li, link_to(t(:open_new_discussion, default: "Open Discussion"), new_admin_topic_path), class: 'visible-xs hidden-lg hidden-md hidden-sm') if current_user.is_agent? %>
           <%= content_tag(:li, link_to(t(:settings, default: "Settings"), admin_settings_path), class: 'visible-xs hidden-lg hidden-md hidden-sm') if current_user.is_admin? %>

--- a/app/views/layouts/admin-settings.html.erb
+++ b/app/views/layouts/admin-settings.html.erb
@@ -48,6 +48,7 @@
 						      <%= settings_menu_item('glyphicon glyphicon-envelope', 'email', admin_email_settings_path) %>
 						      <%= settings_menu_item('fa fa-cogs', 'integrations', admin_integration_settings_path) %>
 						      <%= settings_menu_item('glyphicon glyphicon-user', 'users', admin_users_path) %>
+						      <%= settings_menu_item('glyphicon glyphicon-tags', 'groups', admin_groups_path) %>
 						    </ul>
 								<% end %>
 						  </div>

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -46,8 +46,11 @@
       });
     </script>
     <% end %>
-
-    <%= f.input(:team_list, collection: @all_teams, :label => t(:assign_to), locale: I18n.locale, prompt: "", style: "display:none;") if teams? and !@widget and @all_teams.count > 0 %>
+    
+    <% if teams = all_teams %>
+      <%= f.input(:team_list, collection: teams, :label => t(:assign_to), locale: I18n.locale, prompt: "", style: "display:none;") if teams? and teams.count > 0 %>
+    <% end %>
+    
     <%= f.input :name, input_html: { value: params[:q], class: 'suggest-results' }, :size => 40,  placeholder: I18n.t(:subject), label: I18n.t(:subject), class: 'disable-empty topic-placeholder' %>
 
     <div class="suggestion-results-container hidden">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -133,6 +133,7 @@ Rails.application.routes.draw do
     resources :users
     scope 'settings' do
       resources :api_keys, except: [:show, :edit, :update]
+      resources :groups
     end
     resources :topics, except: [:delete, :edit] do
       resources :posts

--- a/db/migrate/20170121155626_add_columns_to_tag.rb
+++ b/db/migrate/20170121155626_add_columns_to_tag.rb
@@ -1,0 +1,7 @@
+class AddColumnsToTag < ActiveRecord::Migration
+  def change
+    add_column :tags, :show_on_helpcenter, :boolean, :default => false
+    add_column :tags, :show_on_admin, :boolean, :default => false
+    add_column :tags, :show_on_dashboard, :boolean, :default => false
+  end
+end

--- a/db/migrate/20170302162152_add_fields_to_tag.rb
+++ b/db/migrate/20170302162152_add_fields_to_tag.rb
@@ -1,0 +1,7 @@
+class AddFieldsToTag < ActiveRecord::Migration
+  def change
+    add_column :tags, :description, :text
+    add_column :tags, :color, :string
+    add_column :tags, :active, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170224002302) do
+ActiveRecord::Schema.define(version: 20170302162152) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -204,6 +204,9 @@ ActiveRecord::Schema.define(version: 20170224002302) do
     t.boolean "show_on_helpcenter", default: false
     t.boolean "show_on_admin",      default: false
     t.boolean "show_on_dashboard",  default: false
+    t.text    "description"
+    t.string  "color"
+    t.boolean "active",             default: true
   end
 
   add_index "tags", ["name"], name: "index_tags_on_name", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170128182239) do
+ActiveRecord::Schema.define(version: 20170224002302) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,29 +43,6 @@ ActiveRecord::Schema.define(version: 20170128182239) do
   end
 
   add_index "attachinary_files", ["attachinariable_type", "attachinariable_id", "scope"], name: "by_scoped_parent", using: :btree
-
-  create_table "audits", force: :cascade do |t|
-    t.integer  "auditable_id"
-    t.string   "auditable_type"
-    t.integer  "associated_id"
-    t.string   "associated_type"
-    t.integer  "user_id"
-    t.string   "user_type"
-    t.string   "username"
-    t.string   "action"
-    t.text     "audited_changes"
-    t.integer  "version",         default: 0
-    t.string   "comment"
-    t.string   "remote_address"
-    t.string   "request_uuid"
-    t.datetime "created_at"
-  end
-
-  add_index "audits", ["associated_id", "associated_type"], name: "associated_index", using: :btree
-  add_index "audits", ["auditable_id", "auditable_type"], name: "auditable_index", using: :btree
-  add_index "audits", ["created_at"], name: "index_audits_on_created_at", using: :btree
-  add_index "audits", ["request_uuid"], name: "index_audits_on_request_uuid", using: :btree
-  add_index "audits", ["user_id", "user_type"], name: "user_index", using: :btree
 
   create_table "categories", force: :cascade do |t|
     t.string   "name"
@@ -223,7 +200,10 @@ ActiveRecord::Schema.define(version: 20170128182239) do
 
   create_table "tags", force: :cascade do |t|
     t.string  "name"
-    t.integer "taggings_count", default: 0
+    t.integer "taggings_count",     default: 0
+    t.boolean "show_on_helpcenter", default: false
+    t.boolean "show_on_admin",      default: false
+    t.boolean "show_on_dashboard",  default: false
   end
 
   add_index "tags", ["name"], name: "index_tags_on_name", unique: true, using: :btree

--- a/test/controllers/admin/groups_controller_test.rb
+++ b/test/controllers/admin/groups_controller_test.rb
@@ -33,4 +33,27 @@ class Admin::GroupsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "an admin should be able to create new group with dummy tagging" do
+    sign_in users(:admin)
+    params = {acts_as_taggable_on_tag: {name: "test_tag", show_on_helpcenter: true, show_on_admin: true, show_on_dashboard: true}}
+    assert_difference "ActsAsTaggableOn::Tag.count", 1 do
+      post :create, params
+    end  
+  end
+
+  test "an admin should be able to delete group" do
+    sign_in users(:admin)
+    tag = FactoryGirl.create(:acts_as_taggable_on_tag)
+    assert_difference "ActsAsTaggableOn::Tag.count", -1 do
+      delete :destroy, { id: tag.id, locale: "en" }
+    end  
+  end
+
+  test "an admin should be able to update group" do
+    sign_in users(:admin)
+    tag = FactoryGirl.create(:acts_as_taggable_on_tag)
+    put :update, { id: tag.id, acts_as_taggable_on_tag: {show_on_admin: true}} 
+    assert_equal ActsAsTaggableOn::Tag.last.show_on_admin, true 
+  end
+
 end

--- a/test/controllers/admin/groups_controller_test.rb
+++ b/test/controllers/admin/groups_controller_test.rb
@@ -1,0 +1,36 @@
+# == Schema Information
+#
+# Table name: tags
+#
+#  id           :integer          not null, primary key
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+
+require 'test_helper'
+
+class Admin::GroupsControllerTest < ActionController::TestCase
+
+  setup do
+    set_default_settings
+  end
+
+  test "a signed out user should not be able to load the group page" do
+    sign_in users(:user)
+    get :index, locale: :en
+    assert_redirected_to root_path
+  end
+
+  test "a signed in user should not be able to load the group page" do
+    sign_in users(:user)
+    get :index, locale: :en
+    assert_redirected_to root_path
+  end
+
+  test "an admin should be able to load the group page" do
+    sign_in users(:admin)
+    get :index, locale: :en
+    assert_response :success
+  end
+
+end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -114,4 +114,11 @@ FactoryGirl.define do
     body 'Hello!'
   end
 
+  factory :acts_as_taggable_on_tag, class: ActsAsTaggableOn::Tag do
+    name "test_tag"
+    show_on_admin false
+    show_on_helpcenter false
+    show_on_dashboard false
+  end
+
 end


### PR DESCRIPTION
This PR brings significant enhancement to the groups functionality in Helpy with new options and a management UI:

- Allows for creation, editing and removal of groups from a settings panel
- Can set a custom color for groups
- Can determine whether groups are assignable via the internal ticket creation form, or the external form, or neither.