### PR TITLE
Remove the redundant setting.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,7 +66,6 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: Settings.site_url }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = Settings.send_email
-  config.action_mailer.raise_delivery_errors = false
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
`config.action_mailer.raise_delivery_errors` will be `false` by default.

And it will cause some confusion to users
as there have the comment `# config.action_mailer.raise_delivery_errors = false` above it.
