### PR TITLE
Allow Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 2.2.5
   - 2.3.1
+  - 2.4.0
 
 services:
   - postgresql

--- a/Gemfile
+++ b/Gemfile
@@ -189,4 +189,4 @@ group :production do
   gem 'unicorn'
 end
 
-ruby '>= 2.2', '< 2.4'
+ruby '>= 2.2', '< 3.0'


### PR DESCRIPTION
Aside from some warnings in dependencies, Helpy runs great on Ruby 2.4. This just relaxes the Ruby version dependency to support anything below Ruby 3 as there shouldn't be any changes preventing newer Ruby 2.x support.