### PR TITLE
Add role filter to users index, team link from settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 2.2.5
   - 2.3.1
+  - 2.4.1
 
 services:
   - postgresql

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'sass-rails', '~> 5.0.6'
 gem 'uglifier', '>= 1.3.0'
 
 # Explicitly include Nokogiri to control version
-gem 'nokogiri', '>= 1.6.8'
+gem 'nokogiri', '>= 1.7.1'
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,7 +328,7 @@ GEM
     mustermann-grape (0.4.0)
       mustermann (= 0.4.0)
     netrc (0.11.0)
-    nokogiri (1.7.0.1)
+    nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
     oauth (0.5.1)
     oauth2 (1.1.0)
@@ -640,7 +640,7 @@ DEPENDENCIES
   mini_magick
   minitest
   minitest-reporters
-  nokogiri (>= 1.6.8)
+  nokogiri (>= 1.7.1)
   omniauth
   omniauth-facebook
   omniauth-github

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -53,7 +53,16 @@ class Admin::UsersController < Admin::BaseController
   respond_to :html, :js
 
   def index
-    @users = User.all.page params[:page]
+    @roles = [['Team', 'team'], [t(:admin_role), 'admin'], [t(:agent_role), 'agent'], [t(:editor_role), 'editor'], [t(:user_role), 'user']]
+    if params[:role].present?
+      if params[:role] == 'team'
+        @users = User.team.all.page params[:page]
+      else
+        @users = User.by_role(params[:role]).all.page params[:page]
+      end
+    else
+      @users = User.all.page params[:page]
+    end
     @user = User.new
   end
 

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -192,6 +192,49 @@ module AdminHelper
     end
   end
 
+  def user_page_title_text(role)
+    case role
+      when 'user'
+        "#{t(:user_role).pluralize(2)}"
+      when 'agent'
+        "#{t(:agent_role).pluralize(2)}"
+      when 'editor'
+        "#{t(:editor_role).pluralize(2)}"
+      when 'admin'
+        "#{t(:admin_role).pluralize(2)}"
+      when 'team'
+        "Team"
+      else
+        "#{t(:users)}"
+    end
+
+  end
+
+
+  def user_filter
+    content_tag :span, class: 'btn-group' do
+      concat user_filter_select
+      concat user_filter_options
+    end
+  end
+
+  def user_filter_select
+    content_tag :button, class: 'btn btn-default dropdown-toggle', data: { toggle: 'dropdown' } do
+      content_tag :span, class: 'btn' do
+        ("Filter " + icon('caret-down')).html_safe
+      end
+    end
+  end
+
+  def user_filter_options
+    content_tag :ul, class: 'dropdown-menu', role: 'menu' do
+      @roles.each do |u|
+        concat content_tag :li, link_to(u[0], admin_users_path(role: u[1]))
+      end
+    end
+  end
+
+
   def admin_teams
     ActsAsTaggableOn::Tagging.all.where(context: "teams").includes(:tag).where("context = 'teams' and tags.show_on_admin = ?", 'true').references(:tags).map{|tagging| tagging.tag.name.capitalize }.uniq
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -109,7 +109,9 @@ class User < ActiveRecord::Base
   # TODO: Will want to refactor this using .or when upgrading to Rails 5
   scope :admins, -> { where('admin = ? OR role = ?',true,'admin').order('name asc') }
   scope :agents, -> { where('admin = ? OR role = ? OR role = ?',true,'admin','agent').order('name asc') }
+  scope :team, -> { where('admin = ? OR role = ? OR role = ? OR role = ?',true,'admin','agent','editor').order('name asc') }
   scope :active, -> { where('active = ?', true)}
+  scope :by_role, -> (role) { where('role = ?', role) }
 
   def set_role_on_invitation_accept
     if self.role.nil?

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -18,7 +18,8 @@
         <%= settings_item('glyphicon glyphicon-modal-window', "widget", t('widget_description', default: "Find out how to deploy the Helpy widget on your site."), admin_widget_settings_path) %>
         <%= settings_item('glyphicon glyphicon-envelope', "email", t('email_description', default: "Set up SMTP and Inbound email for your Helpy."), admin_email_settings_path) %>
         <%= settings_item('fa fa-cogs', "integrations", t('integrations_description', default: "Configure integrations with external services."), admin_integration_settings_path) %>
-        <%= settings_item('glyphicon glyphicon-user', "users", t('users_description', default: "View and Add Users"), admin_users_path) %>
+        <%= settings_item('fa fa-users', "customers", t('users_description', default: "See and invite your customers"), admin_users_path(role: 'user')) %>
+        <%= settings_item('fa fa-briefcase', "team", t('users_description', default: "View and edit your support team"), admin_users_path(role: 'team')) %>
         <%= settings_item('glyphicon glyphicon-tags', t('team_group', default: "Groups"),
           t('group_description', default: "Edit, Delete, Create team list."), admin_groups_path) %>
       </div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,7 +1,7 @@
 <% title "#{admin_title} #{t('users', default: "Users")}" %>
 
 <h2 id="ticket-page-title">
-  <%= t(:users, default: "Users") %>:
+  <%= user_page_title_text(params[:role]) %>: <%= user_filter %>
   <span class='label <%= status_class(@status) %>' style='text-transform: uppercase'>
     <%= status_label(@status) if @status %>
   </span>

--- a/app/views/layouts/admin-settings.html.erb
+++ b/app/views/layouts/admin-settings.html.erb
@@ -47,7 +47,10 @@
 						      <%= settings_menu_item('glyphicon glyphicon-modal-window', 'widget', admin_widget_settings_path) %>
 						      <%= settings_menu_item('glyphicon glyphicon-envelope', 'email', admin_email_settings_path) %>
 						      <%= settings_menu_item('fa fa-cogs', 'integrations', admin_integration_settings_path) %>
-						      <%= settings_menu_item('glyphicon glyphicon-user', 'users', admin_users_path) %>
+						      <%#= settings_menu_item('glyphicon glyphicon-user', 'users', admin_users_path) %>
+									<%= settings_menu_item('fa fa-users', "customers", admin_users_path(role: 'user')) %>
+					        <%= settings_menu_item('fa fa-briefcase', "team", admin_users_path(role: 'team')) %>
+
 						      <%= settings_menu_item('glyphicon glyphicon-tags', 'groups', admin_groups_path) %>
 						    </ul>
 								<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -178,7 +178,7 @@ en:
   admin_role: Admin
   agent_role: Agent
   editor_role: Editor
-  user_role: User
+  user_role: Customer
   add_more_agents: "Add more users"
 
   # User search results

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -72,6 +72,19 @@ class Admin::UsersControllerTest < ActionController::TestCase
   # admins
 
   %w(admin agent).each do |admin|
+
+    test "an #{admin} should be able to see a listing of users" do
+      sign_in users(admin.to_sym)
+      get :index
+      assert_equal 8, assigns(:users).count
+    end
+
+    test "an #{admin} should be able to see a filtered of users" do
+      sign_in users(admin.to_sym)
+      get :index, { role: 'user' }
+      assert_equal 4, assigns(:users).count
+    end
+
     test "an #{admin} should be able to update a user" do
       sign_in users(admin.to_sym)
       assert_difference("User.find(2).name.length", -3) do
@@ -118,5 +131,14 @@ class Admin::UsersControllerTest < ActionController::TestCase
       end
     end
   end
+
+  %w(user editor).each do |unauthorized|
+    test "an #{unauthorized} should NOT be able to see the list of users" do
+      sign_in users(unauthorized.to_sym)
+      get :index
+      assert_nil assigns(:users)
+    end
+  end
+
 
 end


### PR DESCRIPTION
Adds the ability to filter the user index by role, and also adds a button to settings to view the support team or customers.  Needs a few tests still.