### PR TITLE
Fix on docs comments showed time

### DIFF
--- a/app/views/docs/_comment.html.erb
+++ b/app/views/docs/_comment.html.erb
@@ -14,7 +14,7 @@
 		<%= avatar_image(comment.user, size=40) %>
 	</div>
 	<div class="media-body media-right">
-		<span class="hidden-sm hidden-md hidden-lg"><%= comment.kind == "first" ? last_active_time(comment.created_at) : "#{distance_of_time_in_words(comment.created_at,comment.topic.created_at)} later" %><br/></span>
+		<span class="hidden-sm hidden-md hidden-lg"><%= last_active_time(comment.created_at) %><br/></span>
 		<span id="row-<%= comment.id %>"  class="post-menu post-menu-<%= comment.id %> btn-group">
 			<%=
 			content_tag(:span, class: 'more-important') do
@@ -25,7 +25,7 @@
 
 		<span class="last-active posted-at less-important pull-right">
 			<span class="hidden-xs">
-			<%= comment.kind == "first" ? last_active_time(comment.created_at) : "#{distance_of_time_in_words(comment.created_at,comment.topic.created_at)} later" %>
+			<%= last_active_time(comment.created_at) %>
 			</span>
 		</span>
 


### PR DESCRIPTION
Docs comments are displaying wrong sequence of time, the recently comments get the first comment time, and the comments seems to be inverted in chronologic line. I've made some screenshots for more understanding.

Before fix:
![error_on_time](https://cloud.githubusercontent.com/assets/5271543/24326050/a43d822c-1184-11e7-9dbf-fca7fe8995c2.PNG)


After fix:

![fixed_time](https://cloud.githubusercontent.com/assets/5271543/24326053/b1788e32-1184-11e7-897c-b8bf8360aa6f.PNG)
