### PR TITLE
Creating new internal note layout to made the concept more distinctive

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -121,7 +121,8 @@ td > img {
   border: 1px solid #BCE8F1;
   border-radius: 3px;
 
-  p, span {
+  p,
+  span {
     color: #31708F;
   }
 }

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -114,6 +114,18 @@ td > img {
 	padding-top: 10px;
 	padding-bottom: 0;
 }
+
+.kind-note {
+  background: #D9EDF7;
+  color: #31708F;
+  border: 1px solid #BCE8F1;
+  border-radius: 3px;
+
+  p, span {
+    color: #31708F;
+  }
+}
+
 // === ADMIN STYLES ===
 
 .white-bg {


### PR DESCRIPTION
Internal notes now have another layout class style. This style is focused to create a instant visual separator, when note show in post timeline, the internal note now contains a blue "container" to group information inside.
This PR is references of #498 
Look the example:
![after](https://cloud.githubusercontent.com/assets/5271543/24385452/86ea3694-1340-11e7-94a8-f4bf84e03913.PNG)
