### PR TITLE
Grape API correctly handle with Internal KB docs and categories

### DIFF
--- a/app/controllers/api/v1/categories.rb
+++ b/app/controllers/api/v1/categories.rb
@@ -22,7 +22,7 @@ module API
           optional :docs_limit, type: Integer, desc: "How many docs to return with the category"
         end
         get "", root: :categories do
-          categories = Category.includes(:translations).active.ordered.all
+          categories = Category.includes(:translations).active.publicly.ordered.all
           present categories, with: Entity::Category, docs: permitted_params[:docs], docs_limit: permitted_params[:docs_limit]
         end
 
@@ -35,7 +35,7 @@ module API
           requires :id, type: String, desc: "Category to list docs from"
         end
         get ":id", root: :categories do
-          category = Category.active.find(permitted_params[:id])
+          category = Category.active.publicly.find(permitted_params[:id])
           present category, with: Entity::Category, docs: true
         end
 

--- a/app/controllers/api/v1/docs.rb
+++ b/app/controllers/api/v1/docs.rb
@@ -22,7 +22,7 @@ module API
           optional :category, type: Boolean, desc: "Whether to return the category object in full"
         end
         get ":id", root: "doc" do
-          doc = Doc.active.find(permitted_params[:id])
+          doc = Doc.active.publicly.find(permitted_params[:id])
           present doc, with: Entity::Doc, category: permitted_params[:category]
         end
 

--- a/app/models/doc.rb
+++ b/app/models/doc.rb
@@ -64,6 +64,7 @@ class Doc < ActiveRecord::Base
   scope :recent, -> { order('last_updated DESC').limit(5) }
   scope :all_public_popular, -> { where(active: true).order('points DESC').limit(6) }
   scope :replies, -> { where(category_id: 1) }
+  scope :publicly, -> { joins(:category).where(categories: { visibility: %w[all public] }) }
 
   def to_param
     "#{id}-#{title.parameterize}"

--- a/test/controllers/api/v1/categories_test.rb
+++ b/test/controllers/api/v1/categories_test.rb
@@ -25,7 +25,7 @@ class API::V1::CategoriesTest < ActiveSupport::TestCase
   def app
     Rails.application
   end
-  
+
   setup do
     set_default_settings
     @user = users(:admin)
@@ -38,7 +38,7 @@ class API::V1::CategoriesTest < ActiveSupport::TestCase
 
     # Check not authorized
     assert_equal 401, last_response.status
-  end 
+  end
 
   test "an API user should be able to return categories" do
     get '/api/v1/categories.json', @default_params
@@ -48,7 +48,7 @@ class API::V1::CategoriesTest < ActiveSupport::TestCase
 
     # Check returned value
     objects = JSON.parse(last_response.body)
-    assert objects.length == Category.active.count, "Only #{objects.length} returned out of #{Category.active.count} categories"
+    assert objects.length == Category.active.publicly.count, "Only #{objects.length} returned out of #{Category.active.count} categories"
   end
 
   test "an API user should be able to return a specific category" do
@@ -59,13 +59,21 @@ class API::V1::CategoriesTest < ActiveSupport::TestCase
     assert last_response.ok?, "Response was #{last_response.status}, expected 200"
 
     # Check returned value
-    object = JSON.parse(last_response.body)  
+    object = JSON.parse(last_response.body)
     assert object['id'] == category.id
     assert object['name'] == category.name
   end
 
   test "an API user should not be able to return inactive categories" do
     category = Category.find_by(active: false)
+    get "/api/v1/categories/#{category.id}.json", @default_params
+
+    # Check not found
+    assert_equal 404, last_response.status
+  end
+
+  test "an API user should not be able to return internal categories" do
+    category = Category.find_by(active: true, visibility: 'internal')
     get "/api/v1/categories/#{category.id}.json", @default_params
 
     # Check not found

--- a/test/controllers/api/v1/docs_test.rb
+++ b/test/controllers/api/v1/docs_test.rb
@@ -32,7 +32,7 @@ class API::V1::DocsTest < ActiveSupport::TestCase
   def app
     Rails.application
   end
-  
+
   setup do
     set_default_settings
     @user = users(:admin)
@@ -46,7 +46,7 @@ class API::V1::DocsTest < ActiveSupport::TestCase
 
     # Check not authorized
     assert_equal 401, last_response.status
-  end 
+  end
 
   test "an API user should be able to return a specific doc" do
     doc = Doc.first
@@ -56,13 +56,21 @@ class API::V1::DocsTest < ActiveSupport::TestCase
     assert last_response.ok?, "Response was #{last_response.status}, expected 200"
 
     # Check returned value
-    object = JSON.parse(last_response.body)  
+    object = JSON.parse(last_response.body)
     assert object['id'] == doc.id
     assert object['title'] == doc.title
   end
 
   test "an API user should not be able to return inactive docs" do
     doc = Doc.find_by(active: false)
+    get "/api/v1/docs/#{doc.id}.json", @default_params
+
+    # Check not found
+    assert_equal 404, last_response.status
+  end
+
+  test "an API user should not be able to return internal docs" do
+    doc = Doc.joins(:category).find_by(active: true, categories: { visibility: 'internal' })
     get "/api/v1/docs/#{doc.id}.json", @default_params
 
     # Check not found

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -50,6 +50,14 @@ four:
   rank: 40
   visibility: 'all'
 
+six:
+  id: 6
+  name: internal title
+  active: true
+  front_page: true
+  rank: 40
+  visibility: 'internal'
+
 common_replies:
   id: 5
   name: Common Replies

--- a/test/fixtures/docs.yml
+++ b/test/fixtures/docs.yml
@@ -108,6 +108,18 @@ seven:
   front_page: false
   allow_comments: true
 
+nine:
+  id: 9
+  title: Article inside internal category
+  body: This doc should allow comments
+  keywords:
+  category_id: 6
+  user_id: 1
+  active: true
+  rank: 67
+  front_page: false
+  allow_comments: true
+
 common:
   id: 8
   title: Common Reply


### PR DESCRIPTION
This fix is references of #608 , that new internal KB items shows on API endpoints. The fix now guarantee that only public items will be showed by API.