### PR TITLE
Creating a virtual identification between categories for distinct purposes

### DIFF
--- a/app/controllers/admin/internal_categories_controller.rb
+++ b/app/controllers/admin/internal_categories_controller.rb
@@ -1,11 +1,11 @@
 class Admin::InternalCategoriesController < Admin::BaseController
 
   def index
-    @categories = Category.internally.ordered
+    @categories = Category.internally.without_system_resource.ordered
   end
 
   def show
-    @category = Category.internally.active.where(id: params[:id]).first
+    @category = Category.internally.without_system_resource.active.where(id: params[:id]).first
     if @category
       if I18n.available_locales.count > 1
         @docs = @category.docs.ordered.active.with_translations(I18n.locale).page params[:page]

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -32,6 +32,7 @@ class Category < ActiveRecord::Base
 
   PUBLIC_VIEWABLE   = %w[all public]
   INTERNAL_VIEWABLE = %w[all internal]
+  SYSTEM_RESOURCES = ["Common Replies", "Email templates"]
 
   scope :alpha, -> { order('name ASC') }
   scope :active, -> { where(active: true) }
@@ -42,6 +43,7 @@ class Category < ActiveRecord::Base
   scope :publicly, -> { where(visibility: PUBLIC_VIEWABLE) }
   scope :internally, -> { where(visibility: INTERNAL_VIEWABLE) }
   scope :only_internally, -> { where(visibility: 'internal') }
+  scope :without_system_resource, -> { where.not(name: SYSTEM_RESOURCES)  }
 
   before_destroy :non_deleteable?
 


### PR DESCRIPTION
This PR references of #610 .

Internal categories shows some categories that would be used only by "system" in other areas of Helpy, like   "Common Replies".