### PR TITLE
PR for issue 632 - Refactor && DRY new user creation method

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -255,23 +255,13 @@ class User < ActiveRecord::Base
   end
 
   def self.register email, user_name
-    # this method is very similar to email_processor#create_user
-    # actually it was copyied from there.
-    # it should create an issue to properly refactor and
-    # preserve the DRY principle.
-
     # create user
     usr = User.new
-
-    token, enc = Devise.token_generator.generate(User, :reset_password_token)
-    usr.reset_password_token = enc
-    usr.reset_password_sent_at = Time.now.utc
-
     usr.email = email
     usr.name = user_name
-    usr.password = User.create_password
-    if usr.save
-      UserMailer.new_user(usr.id, token).deliver_later
+
+    if usr.signup_guest
+      UserMailer.new_user(usr.id, usr.reset_password_token).deliver_later
     end
 
     return usr

--- a/lib/email_processor.rb
+++ b/lib/email_processor.rb
@@ -140,19 +140,8 @@ class EmailProcessor
   end
 
   def create_user
-    # create user
-    @user = User.new
-
-    @token, enc = Devise.token_generator.generate(User, :reset_password_token)
-    @user.reset_password_token = enc
-    @user.reset_password_sent_at = Time.now.utc
-
-    @user.email = @email.from[:email]
-    @user.name = @email.from[:name].blank? ? @email.from[:token].gsub(/[^a-zA-Z]/, '') : @email.from[:name]
-    @user.password = User.create_password
-    if @user.save
-      UserMailer.new_user(@user.id, @token).deliver_later
-    end
-
+    usr_email = @email.from[:email]
+    usr_name  = @email.from[:name].blank? ? @email.from[:token].gsub(/[^a-zA-Z]/, '') : @email.from[:name]
+    @user = User.register usr_email, usr_name
   end
 end


### PR DESCRIPTION
Refactor of email_processor#create_user to use user#register. Now user#register is also using the previous existent user#signup_guest.

@scott although refactor doesn't require tests, this refactor has no tests at all! 
The refactor won't have any problems though, because semantically is the same thing. However I think it would the better to open an issue to create tests specially for user::register since it's a very meaningful method.
