### PR TITLE
Link roadmap text to the Trello board.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Welcome, and thanks for contributing to Helpy.  Together we are building the bes
 - Refactoring
 - Improve test coverage-  As with any large and growing codebase, test coverage is not always as good as it could be.  Help improving test coverage is always welcome and will help you learn how Helpy works.  We use Minitest exclusively.
 - Translate the project- The community has already translated Helpy into 18 languages, but there are many more waiting.  We need help getting Helpy translated into as many locales as possible! [please see the guide to translation](http://support.helpy.io/en/knowledgebase/12-Using-Helpy/docs/4-Supported-locales-How-to-Contribute)
-- Build new features.  There is a backlog of new features that we’d like to see built.  Check out our roadmap for more insight on this, and if you would like to take one on, please get in touch with us to make sure someone is not already working on it.
+- Build new features.  There is a backlog of new features that we’d like to see built.  Check out our [roadmap](https://trello.com/b/NuiWsdmK/helpy) for more insight on this, and if you would like to take one on, please get in touch with us to make sure someone is not already working on it.
 
 **General Guidelines:**
 


### PR DESCRIPTION
It's a small change to make it easier for new folks to get involved.