### PR TITLE
Associate a from specific email address for each team

### DIFF
--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -72,6 +72,8 @@ class Admin::GroupsController < Admin::BaseController
       :name,
       :description,
       :color,
+      :email_address,
+      :email_name,
       :show_on_helpcenter,
       :show_on_admin,
       :show_on_dashboard

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -256,4 +256,8 @@ module AdminHelper
     end
   end
 
+  def inbound_group_email(group, from_email)
+    "#{from_email.split('@')[0]}+#{group}@#{from_email.split('@')[1]}" if group.present? && from_email.present?
+  end
+
 end

--- a/app/mailers/post_mailer.rb
+++ b/app/mailers/post_mailer.rb
@@ -14,7 +14,7 @@ class PostMailer < ActionMailer::Base
     end
     mail(
       to: email_with_name,
-      from: %("#{AppSettings['settings.site_name']}" <#{AppSettings['email.admin_email']}>),
+      from: @topic.from_email_address,
       subject: "[#{AppSettings['settings.site_name']}] ##{@topic.id}-#{@topic.name}"
       )
   end

--- a/app/mailers/topic_mailer.rb
+++ b/app/mailers/topic_mailer.rb
@@ -12,7 +12,7 @@ class TopicMailer < ActionMailer::Base
       to: email_with_name,
       cc: @post.cc,
       bcc: @post.bcc,
-      from: %("#{AppSettings['settings.site_name']}" <#{AppSettings['email.admin_email']}>),
+      from: @topic.from_email_address,
       subject: "[#{AppSettings['settings.site_name']}] ##{@topic.id}-#{@topic.name}"
       )
   end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -253,6 +253,18 @@ class Topic < ActiveRecord::Base
     end
   end
 
+  def from_email_address
+    system_from_email = %("#{AppSettings['settings.site_name']}" <#{AppSettings['email.admin_email']}>)
+    return system_from_email if self.team_list.blank?
+
+    team = ActsAsTaggableOn::Tag.where('lower(name) = ?', self.team_list.first.downcase).first
+    if team.email_address.present?
+      %("#{team.email_name}" <#{team.email_address}>)
+    else
+      system_from_email
+    end
+  end
+
   private
 
   def cache_user_name

--- a/app/views/admin/groups/_form.html.erb
+++ b/app/views/admin/groups/_form.html.erb
@@ -1,15 +1,21 @@
-
   <div class="settings-section group">
     <%= f.input 'name', label: t(:tag_name, default: "Group Name"), placeholder: t(:tag_name, default: 'Group Name') %>
     <%= f.input 'description', label: t('description', default: "Description") %>
     <%= f.input 'color', inline_label: t('color', default: "Color"), input_html: { class: 'pick-a-color' } %>
     <br/>
-    <%= f.input 'email_address', label: t('email_address', default: "Email Address") %>
-    <%= f.input 'email_name', inline_label: t('name', default: "Name") %>
-
     <%= f.input 'show_on_helpcenter', checked: @team.show_on_helpcenter, label: t('show_on_helpcenter', default: "Show on helpcenter"), label_html: { class: 'full-width' }, input_html: { class: 'bs-toggle', data: { size: 'mini' } } %>
     <%= f.input 'show_on_admin', checked: @team.show_on_admin, label: t('show_on_admin', default: "Show on admin"), label_html: { class: 'full-width' }, input_html: { class: 'bs-toggle', data: { size: 'mini' } } %>
     <%#= f.check_box 'show_on_dashboard', checked: @team.show_on_dashboard, label: t('show_on_dashboard', default: "Show on dashboard"), label_html: { class: 'full-width' }, input_html: { class: 'bs-toggle', data: { size: 'mini' } }%>
+
+    <br/>
+    <span class="tiny-header">Group Email (optional)</span><br/>
+    Any tickets in this group will appear to come from the following address:
+    <br/><br/><br/>
+    <!-- <p>Send email to this group using an alias on your main support address, ie. <%#= inbound_group_email(@team.name, AppSettings['email.from_email']) %></p> -->
+    <%= f.input 'email_address', label: t('email_address', default: "Email Address") %>
+    <%= f.input 'email_name', label: t('from_name', default: "From Name") %>
+
+
   </div>
   <div class="submit-section">
     <%= f.button :submit, "Save Settings", class: 'btn btn-warning' %>

--- a/app/views/admin/groups/_form.html.erb
+++ b/app/views/admin/groups/_form.html.erb
@@ -4,6 +4,9 @@
     <%= f.input 'description', label: t('description', default: "Description") %>
     <%= f.input 'color', inline_label: t('color', default: "Color"), input_html: { class: 'pick-a-color' } %>
     <br/>
+    <%= f.input 'email_address', label: t('email_address', default: "Email Address") %>
+    <%= f.input 'email_name', inline_label: t('name', default: "Name") %>
+
     <%= f.input 'show_on_helpcenter', checked: @team.show_on_helpcenter, label: t('show_on_helpcenter', default: "Show on helpcenter"), label_html: { class: 'full-width' }, input_html: { class: 'bs-toggle', data: { size: 'mini' } } %>
     <%= f.input 'show_on_admin', checked: @team.show_on_admin, label: t('show_on_admin', default: "Show on admin"), label_html: { class: 'full-width' }, input_html: { class: 'bs-toggle', data: { size: 'mini' } } %>
     <%#= f.check_box 'show_on_dashboard', checked: @team.show_on_dashboard, label: t('show_on_dashboard', default: "Show on dashboard"), label_html: { class: 'full-width' }, input_html: { class: 'bs-toggle', data: { size: 'mini' } }%>

--- a/db/migrate/20170609170131_add_email_to_groups.rb
+++ b/db/migrate/20170609170131_add_email_to_groups.rb
@@ -1,0 +1,6 @@
+class AddEmailToGroups < ActiveRecord::Migration
+  def change
+    add_column :tags, :email_address, :string
+    add_column :tags, :email_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170302162152) do
+ActiveRecord::Schema.define(version: 20170609170131) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -208,6 +208,8 @@ ActiveRecord::Schema.define(version: 20170302162152) do
     t.text    "description"
     t.string  "color"
     t.boolean "active",             default: true
+    t.string  "email_address"
+    t.string  "email_name"
   end
 
   add_index "tags", ["name"], name: "index_tags_on_name", unique: true, using: :btree

--- a/test/mailers/post_mailer_test.rb
+++ b/test/mailers/post_mailer_test.rb
@@ -11,7 +11,7 @@ class PostMailerTest < ActionMailer::TestCase
     user = topic.user
     user.email = "change@me-something.com"
     user.save!
-    
+
     post = topic.posts.first
     email = PostMailer.new_post(post.id)
 


### PR DESCRIPTION
This lets you specify an email address for each group and have customer notifications use that from email address for tickets assigned to a given group.