### PR TITLE
Fix/557 refactor failing tests

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -41,7 +41,7 @@ class Admin::SettingsController < Admin::BaseController
   end
 
   def profile
-    @user = User.find(current_user)
+    @user = User.find(current_user.id)
     tracker("Agent: #{current_user.name}", "Editing User Profile", @user.name)
     render layout: 'admin-settings'
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -86,8 +86,8 @@ class Admin::UsersController < Admin::BaseController
 
     fetch_counts
 
-    # update team list
-    @user.team_list = params[:user][:team_list]
+    # update team list if provided
+    @user.team_list = params[:user][:team_list] if  params[:user][:team_list].present?
 
     if @user.update(user_params)
 

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -169,5 +169,10 @@ class Admin::SettingsControllerTest < ActionController::TestCase
     assert_equal 'something', Cloudinary.config.api_secret
   end
 
+  test "an agent should be able to update their profile" do
+    sign_in users(:agent)
+    get :profile
+    assert :success
+  end
 
 end

--- a/test/controllers/admin/topics_controller_test.rb
+++ b/test/controllers/admin/topics_controller_test.rb
@@ -189,7 +189,7 @@ class Admin::TopicsControllerTest < ActionController::TestCase
       sign_in users(admin.to_sym)
       xhr :patch, :update_tags, { id: 2, topic: { tag_list: 'hello, hi' } }
       assert_equal 2, Topic.find(2).tag_list.count
-      assert_equal "hi", Topic.find(2).tag_list.first
+      assert_equal true, Topic.find(2).tag_list.include?("hi")
     end
 
     test "an #{admin} should be able to remove tags for a topic" do

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -129,6 +129,22 @@ agent:
   notify_on_private: true
   notify_on_public: true
   notify_on_reply: true
+  bio: 'some bio'
+  signature: 'the signature'
+  work_phone: '999'
+  cell_phone: '888'
+  company: 'company'
+  street: '123 main'
+  city: 'akron'
+  state: 'oh'
+  zip: '45646'
+  title: 'title'
+  twitter: '@tweet'
+  linkedin: 'erge r'
+  language: 'en'
+  priority: normal
+  active: true
+  time_zone:
 
 editor:
   id: 7


### PR DESCRIPTION
#557 

Refactors the admin topic_controller test that regularly fails because the tag ordering is not certain.