### PR TITLE
I18n strings in tests

### DIFF
--- a/app/views/admin/groups/_form.html.erb
+++ b/app/views/admin/groups/_form.html.erb
@@ -18,5 +18,5 @@
 
   </div>
   <div class="submit-section">
-    <%= f.button :submit, "Save Settings", class: 'btn btn-warning' %>
+    <%= f.button :submit, t(:save_settings, default: "Save Settings"), class: 'btn btn-warning' %>
   </div>

--- a/app/views/admin/settings/design.html.erb
+++ b/app/views/admin/settings/design.html.erb
@@ -50,7 +50,7 @@
         <%= f.text_area 'design.footer_js', value: AppSettings['design.footer_js'], label: "Footer Javascript", rows: 10, class: 'css-editor' %>
     </div>
     <div class="submit-section">
-      <%= f.submit "Save Settings", class: 'btn btn-warning' %>
+      <%= f.submit t(:save_settings, default: "Save Settings"), class: 'btn btn-warning' %>
     </div>
 
   <% end %>

--- a/app/views/admin/settings/email.html.erb
+++ b/app/views/admin/settings/email.html.erb
@@ -25,7 +25,7 @@
       </div>
     </div>
     <div class="submit-section">
-      <%= f.submit "Save Settings", class: 'btn btn-warning' %>
+      <%= f.submit t(:save_settings, default: "Save Settings"), class: 'btn btn-warning' %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/admin/settings/general.html.erb
+++ b/app/views/admin/settings/general.html.erb
@@ -23,7 +23,7 @@
 
     </div>
     <div class="submit-section">
-      <%= f.submit "Save Settings", class: 'btn btn-warning' %>
+      <%= f.submit t(:save_settings, default: "Save Settings"), class: 'btn btn-warning' %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/admin/settings/i18n.html.erb
+++ b/app/views/admin/settings/i18n.html.erb
@@ -17,7 +17,7 @@
       </div>
     </div>
     <div class="submit-section">
-      <%= f.submit "Save Settings", class: 'btn btn-warning' %>
+      <%= f.submit t(:save_settings, default: 'Save Settings'), class: 'btn btn-warning' %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/admin/settings/integration.html.erb
+++ b/app/views/admin/settings/integration.html.erb
@@ -63,7 +63,7 @@
 
     </div>
     <div class="submit-section">
-      <%= f.submit "Save Settings", class: 'btn btn-warning' %>
+      <%= f.submit t(:save_settings, default: "Save Settings"), class: 'btn btn-warning' %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/admin/settings/notifications.html.erb
+++ b/app/views/admin/settings/notifications.html.erb
@@ -7,7 +7,7 @@
       <%= t('notifications', default: 'Notifications') %>
     </h2>
   </div>
-  
+
   <div class="settings-panel row">
     <div class="col-md-9 col-sm-8 col-xs-10">
       <%= bootstrap_form_tag url: admin_update_notifications_path, method: 'put', remote: false do |f| %>
@@ -17,7 +17,7 @@
           <%= f.check_box 'notify_on_reply', { checked: current_user.notify_on_reply?, label: t('notify_on_reply', default: "Email me when a new reply to a private discussion has been received"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
         </div>
         <div class="submit-section">
-          <%= f.submit "Save Settings", class: 'btn btn-warning' %>
+          <%= f.submit t(:save_settings, default: "Save Settings"), class: 'btn btn-warning' %>
         </div>
       <% end %>
     </div>

--- a/app/views/admin/settings/theme.html.erb
+++ b/app/views/admin/settings/theme.html.erb
@@ -17,7 +17,7 @@
       </div>
     </div>
     <div class="submit-section">
-      <%= f.submit "Save Settings", class: 'btn btn-warning' %>
+      <%= f.submit t(:save_settings, default: "Save Settings"), class: 'btn btn-warning' %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/admin/settings/widget.html.erb
+++ b/app/views/admin/settings/widget.html.erb
@@ -12,7 +12,7 @@
       <%= f.text_field 'widget.button_text_color', value: AppSettings['widget.button_text_color'], label: t('button_text_color', default: "Widget Text Color"), class: 'pick-a-color' %>
     </div>
     <div class="submit-section">
-      <%= f.submit "Save Settings", class: 'btn btn-warning' %>
+      <%= f.submit t(:save_settings, default: "Save Settings"), class: 'btn btn-warning' %>
     </div>
   <% end %>
   <br/><br/><br/>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -46,7 +46,7 @@
 			<div class="add-form inline-reply">
 			<h4><%= t(:reply) %></h4>
 			<%= bootstrap_form_for :post, :url => topic_posts_path(@topic) do |f| -%>
-			  <%= f.text_area :body, :rows => 4, :cols => 160, label: 'Type your response:' -%></p>
+			  <%= f.text_area :body, :rows => 4, :cols => 160, label: t(:type_response, default: 'Type your response:') -%></p>
 			  <%= f.hidden_field 'kind', value: 'reply' %>
 				<div class="add-screenshots">
 				<%= attachinary_file_field_tag 'post[screenshots]', @topic.posts.new, :screenshots if cloudinary_enabled? %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -29,7 +29,7 @@
 			<h4><%= t(:reply) %></h4>
 			<%#= error_messages_for :post -%>
 			<%= bootstrap_form_for :post, :url => topic_posts_path(@topic) do |f| -%>
-			  <%= f.text_area :body, :rows => 8, :cols => 160, label: 'Type your response:', class: 'disable-empty' -%></p>
+			  <%= f.text_area :body, :rows => 8, :cols => 160, label: t(:type_response, default: 'Type your response:'), class: 'disable-empty' -%></p>
 			  <%= f.hidden_field 'kind', value: 'reply' %>
 				<div class="add-screenshots">
 				<%= attachinary_file_field_tag 'post[screenshots]', @post, :screenshots if cloudinary_enabled? %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -194,7 +194,8 @@ ca:
   asked_a_question: "%{user_name} ha preguntat..."
   replied: "%{user_name} ha contestat..."
   posted_note: "%{user_name} ha penjat com a missatge intern..."
-  type_reply: Escriu la teva resposta, o selecciona des d'un missatge comú a sota
+  type_reply: "Escriu la teva resposta, o selecciona des d'un missatge comú a sota"
+  # type_response: "Type your response:"
   select_common: Selecciona una resposta comuna
   reply: Respon
   internal_note: Nota interna
@@ -256,6 +257,7 @@ ca:
   # widget: "Embeddable Widget"
   # common_replies: "Common Replies"
   # integrations: "Integrations"
+  # save_settings: "Save Settings"
 
 
   # Keyboard Shortcuts

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -206,6 +206,7 @@ de:
   replied: "%{user_name} hat geantwortet..."
   posted_note: "%{user_name} hat eine interne Notiz gesendet..."
   type_reply: Schreiben Sie eine Antwort oder wählen Sie unten eine Textvorlage aus
+  # type_response: "Type your response:"
   select_common: Textvorlage auswählen
   reply: Antworten
   internal_note: Interne Notiz
@@ -281,6 +282,7 @@ de:
   widget: "Einbindbares Widget"
   # common_replies: "Common Replies"
   # integrations: "Integrations"
+  # save_settings: "Save Settings"
 
 
   # API Key Managmeent

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -238,6 +238,7 @@ en:
   replied: "%{user_name} replied..."
   posted_note: "%{user_name} posted an internal note..."
   type_reply: Type your reply, or select from a common message below
+  type_response: "Type your response:"
   select_common: Select Common Reply
   reply: Reply
   internal_note: Internal Note
@@ -317,6 +318,7 @@ en:
   widget: "Embeddable Widget"
   common_replies: "Common Replies"
   integrations: "Integrations"
+  save_settings: "Save Settings"
 
   # API Key Managmeent
   api_keys: "API Keys"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -194,6 +194,7 @@ es:
   replied: "%{user_name} ha contestado..."
   posted_note: "%{user_name} ha enviado un mensaje interno..."
   type_reply: Escribe tu respuesta o selecciona una respuesta pre-definidida.
+  # type_response: "Type your response:"
   select_common: Selecciona una respuesta pre-definidida
   reply: Responder
   internal_note: Nota interna
@@ -256,6 +257,7 @@ es:
   widget: "Incrustar widget"
   # common_replies: "Common Replies"
   # integrations: "Integrations"
+  # save_settings: "Save Settings"
 
   # Keyboard Shortcuts
   # shortcut_then: "then"

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -205,6 +205,7 @@ et:
   replied: "%{user_name} vastas..."
   posted_note: "%{user_name} postitas siseteatise..."
   type_reply: Kirjuta vastus või vali korduma kippuv vastus alt
+  # type_response: "Type your response:"
   select_common: Vali Korduma Kippuv Vastus
   reply: Vasta
   internal_note: Siseteatis
@@ -279,6 +280,7 @@ et:
   international: "Rahvusvaheline"
   widget: "Manustav vidin"
   # integrations: "Integrations"
+  # save_settings: "Save Settings"
 
   # API Key Managmeent
   api_keys: "API võtmed"

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -194,6 +194,7 @@ fa:
   replied: "%{user_name} پاسخ داده..."
   posted_note: "%{user_name} نکته روش نوشته..."
   type_reply: پاسخ خود را بنویسید, یا از پاسخ‌های متداول زیر انتخاب کنید
+  # type_response: "Type your response:"
   select_common: انتخاب پاسخ متداول
   reply: پاسخ
   internal_note: نکته
@@ -269,6 +270,7 @@ fa:
   widget: "کد قابل ادغام"
   common_replies: "پاسخ های متداول"
   integrations: "درونی‌سازی"
+  # save_settings: "Save Settings"
 
   # API Key Managmeent
   api_keys: "کلیدهای API"

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -238,6 +238,7 @@ fi:
   replied: "%{user_name} vastasi..."
   posted_note: "%{user_name} lähetti vastauksen..."
   type_reply: Kirjoita vastauksesi tai valitse yleinen vastaus alta
+  # type_response: "Type your response:"
   select_common: Valitse yleinen vastaus
   reply: Vastaa
   internal_note: Sisäinen merkintä
@@ -317,6 +318,7 @@ fi:
   widget: "Upotettava liitännäinen"
   common_replies: "Yleiset vastaukset"
   integrations: "Integraatiot"
+  # save_settings: "Save Settings"
 
   # API Key Managmeent
   api_keys: "API-avaimet"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -194,6 +194,7 @@ fr:
   replied: "%{user_name} a répondu..."
   posted_note: "%{user_name} a affiché une note interne..."
   type_reply: "Saisissez votre réponse, ou sélectionnez une réponse type ci-dessous"
+  # type_response: "Type your response:"
   select_common: Sélectionner une réponse type
   reply: Réponse
   internal_note: Note interne
@@ -256,6 +257,7 @@ fr:
   widget: "Widget intégré"
   common_replies: "Réponses standard"
   integrations: "Intégrations"
+  # save_settings: "Save Settings"
 
   # Keyboard Shortcuts
   shortcut_then: "puis"

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -194,6 +194,7 @@ hi:
   replied: "%{user_name} जवाब दिया..."
   posted_note: "%{user_name} एक आंतरिक नोट पोस्ट किए..."
   type_reply: आपके उत्तर टाइप करें, या नीचे एक आम संदेश से चुनें
+  # type_response: "Type your response:"
   select_common: एक आम जबाब चुनें
   reply: जवाब
   internal_note: आंतरिक नोट
@@ -257,6 +258,7 @@ hi:
   widget: "Embeddable Widget"
   # common_replies: "Common Replies"
   # integrations: "Integrations"
+  # save_settings: "Save Settings"
 
   # Keyboard Shortcuts
   # shortcut_then: "then"

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -197,6 +197,7 @@ hu:
   replied: "%{user_name} válaszolt..."
   posted_note: "%{user_name} belső jegyzetet írt..."
   type_reply: Írd meg a válaszod, vagy válassz egyet az általános válaszok közül
+  # type_response: "Type your response:"
   select_common: Válasz kijelölése
   reply: Válasz
   internal_note: Belső Jegyzet
@@ -272,6 +273,7 @@ hu:
   widget: "Beágyazható Widget"
   # common_replies: "Common Replies"
   # integrations: "Integrations"
+  # save_settings: "Save Settings"
 
   # API Key Managmeent
   api_keys: "API Kulcsok"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -194,6 +194,7 @@ it:
   replied: "%{user_name} rispondeva..."
   posted_note: "%{user_name} ha scritto una nota interna..."
   type_reply: Typ hier je antwoord of selecteer een van de standaard antwoorden
+  # type_response: "Type your response:"
   select_common: Standaard antwoord selecteren
   reply: Rispondere
   internal_note: Nota interna
@@ -269,6 +270,7 @@ it:
   widget: "Embeddable Widget"
   # common_replies: "Common Replies"
   # integrations: "Integrations"
+  # save_settings: "Save Settings"
 
   # API Key Managmeent
   api_keys: "API Keys"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -194,6 +194,7 @@ ja:
   replied: "%{user_name}さんは返信しました"
   posted_note: "%{user_name}さんは内部メモを投稿する"
   type_reply: "ご記入いただくか、下記のテンプレートより返信内容をお選びください。"
+  # type_response: "Type your response:"
   select_common: "テンプレート選択"
   reply: "返信"
   internal_note: "内部メモ"
@@ -256,6 +257,7 @@ ja:
   widget: "埋め込みウィジェット"
   # common_replies: "Common Replies"
   # integrations: "Integrations"
+  # save_settings: "Save Settings"
 
   # Keyboard Shortcuts
   # shortcut_then: "then"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -194,6 +194,7 @@ nl:
   replied: "%{user_name} antwoordde..."
   posted_note: "%{user_name} heeft een interne notitie toegevoegd..."
   type_reply: Typ hier je antwoord of selecteer een van de standaard antwoorden
+  # type_response: "Type your response:"
   select_common: Standaard antwoord selecteren
   reply: Beantwoorden
   internal_note: Interne Notitie
@@ -256,6 +257,7 @@ nl:
   # widget: "Embeddable Widget"
   # common_replies: "Common Replies"
   # integrations: "Integrations"
+  # save_settings: "Save Settings"
 
   # Keyboard Shortcuts
   # shortcut_then: "then"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -194,6 +194,7 @@ pt:
   replied: "%{user_name} respondeu..."
   posted_note: "%{user_name} criou uma nota interna..."
   type_reply: "Escreva a sua resposta, ou selecione uma predefinida em baixo"
+  # type_response: "Type your response:"
   select_common: "Selecione uma Resposta Predefinida"
   reply: "Responder"
   internal_note: "Nota Interna"
@@ -256,6 +257,7 @@ pt:
   # widget: "Embeddable Widget"
   # common_replies: "Common Replies"
   # integrations: "Integrations"
+  # save_settings: "Save Settings"
 
   # Keyboard Shortcuts
   # shortcut_then: "then"

--- a/config/locales/pt_BR.yml
+++ b/config/locales/pt_BR.yml
@@ -228,6 +228,7 @@ pt-br:
   replied: "%{user_name} respondeu..."
   posted_note: "%{user_name} criou uma nota interna..."
   type_reply: "Escreva a sua resposta, ou selecione uma predefinida em baixo"
+  # type_response: "Type your response:"
   select_common: "Selecione uma Resposta Predefinida"
   reply: "Responder"
   internal_note: "Nota Interna"
@@ -353,6 +354,7 @@ pt-br:
   international: "Internacionalização"
   widget: "Widget embarcado"
   integrations: Integrações
+  # save_settings: "Save Settings"
 
   notifications_description: "Escolha em que momento deseja ser notificado via e-mail"
   api_description: "Crie e gerencie suas chaves de acesso a API Helpy!"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -200,6 +200,7 @@ ru:
   replied: "%{user_name} ответил..."
   posted_note: "%{user_name} опубликовал внутреннюю заметку..."
   type_reply: Введите ответ или выберите из общего сообщения ниже
+  # type_response: "Type your response:"
   select_common: Выберите Общий Ответ
   reply: Ответьте
   internal_note: Внутренняя заметка
@@ -264,6 +265,7 @@ ru:
   # widget: "Embeddable Widget"
   # common_replies: "Common Replies"
   # integrations: "Integrations"
+  # save_settings: "Save Settings"
 
   # Keyboard Shortcuts
   # shortcut_then: "then"

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -181,6 +181,7 @@ sv:
   replied: "%{user_name} svarade..."
   posted_note: "%{user_name} postade en intern anteckning..."
   type_reply: 'Skriv ett svar, eller skicka ett sparat'
+  # type_response: "Type your response:"
   select_common: 'Välj sparat svar'
   reply: 'Svar'
   internal_note: 'Intern anteckning'
@@ -239,6 +240,7 @@ sv:
   widget: "Inbäddningsbar Widget"
   # common_replies: "Common Replies"
   # integrations: "Integrations"
+  # save_settings: "Save Settings"
 
   # Keyboard Shortcuts
   # shortcut_then: "then"

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -194,6 +194,7 @@ tr:
   replied: "%{user_name} yanıtladı..."
   posted_note: "%{user_name} dahili bir not gönderdi..."
   type_reply: Yanıtınızı yazın, ya da aşağıdan genel bir mesaj seçin
+  # type_response: "Type your response:"
   select_common: Genel Cevap Seçin
   reply: Yanıtla
   internal_note: Dahili Not
@@ -256,6 +257,7 @@ tr:
   widget: "Gömülebilir Bileşen"
   # common_replies: "Common Replies"
   # integrations: "Integrations"
+  # save_settings: "Save Settings"
 
   # Keyboard Shortcuts
   # shortcut_then: "then"

--- a/config/locales/zh_CN.yml
+++ b/config/locales/zh_CN.yml
@@ -194,6 +194,7 @@ zh-cn:
   replied: "%{user_name} 回覆…"
   posted_note: "%{user_name} 张贴了内部注解"
   type_reply: 输入你的回覆, 或选择以下常用回覆
+  # type_response: "Type your response:"
   select_common: 选择常用回覆
   reply: 回覆
   internal_note: 内部注解
@@ -256,6 +257,7 @@ zh-cn:
   # widget: "Embeddable Widget"
   # common_replies: "Common Replies"
   # integrations: "Integrations"
+  # save_settings: "Save Settings"
 
   # Keyboard Shortcuts
   # shortcut_then: "then"

--- a/config/locales/zh_TW.yml
+++ b/config/locales/zh_TW.yml
@@ -194,6 +194,7 @@ zh-tw:
   replied: "%{user_name} 回覆…"
   posted_note: "%{user_name} 張貼了內部注解..."
   type_reply: 輸入你的回覆, 或選擇以下常用回覆
+  # type_response: "Type your response:"
   select_common: 選擇常用回覆
   reply: 回覆
   internal_note: 內部注解
@@ -256,6 +257,7 @@ zh-tw:
   # widget: "Embeddable Widget"
   # common_replies: "Common Replies"
   # integrations: "Integrations"
+  # save_settings: "Save Settings"
 
   # Keyboard Shortcuts
   # shortcut_then: "then"

--- a/test/controllers/admin/categories_controller_test.rb
+++ b/test/controllers/admin/categories_controller_test.rb
@@ -33,22 +33,22 @@ class Admin::CategoriesControllerTest < ActionController::TestCase
   end
 
   test "a browsing user should not be able to load edit" do
-    get :edit, { id: 1, locale: :en }
+    get :edit, id: 1, locale: :en
     assert_redirected_to new_user_session_path
   end
 
   test "a browsing user should not be able to load create" do
-    post :create, category: {name: "some name" }, locale: :en
+    post :create, category: { name: "some name" }, locale: :en
     assert_redirected_to new_user_session_path
   end
 
   test "a browsing user should not be able to load update" do
-    patch :update, { id: 1, category: { name: "some name" }, locale: :en }
+    patch :update, id: 1, category: { name: "some name" }, locale: :en
     assert_redirected_to new_user_session_path
   end
 
   test "a browsing user should not be able to load destroy" do
-    delete :destroy, { id: 1, locale: :en }
+    delete :destroy, id: 1, locale: :en
     assert_redirected_to new_user_session_path
   end
 
@@ -62,25 +62,25 @@ class Admin::CategoriesControllerTest < ActionController::TestCase
 
   test "a signed in user should not be able to load edit" do
     sign_in users(:user)
-    get :edit, { id: 1, locale: :en }
+    get :edit, id: 1, locale: :en
     assert_redirected_to root_path
   end
 
   test "a signed in user should not be able to load create" do
     sign_in users(:user)
-    post :create, category: {name: "some name"}, locale: :en
+    post :create, category: { name: "some name"}, locale: :en
     assert_redirected_to root_path
   end
 
   test "a signed in user should not be able to load update" do
     sign_in users(:user)
-    patch :update, { id: 1, category: { name: "some name" }, locale: :en }
+    patch :update, id: 1, category: { name: "some name" }, locale: :en
     assert_redirected_to root_path
   end
 
   test "a signed in user should not be able to load destroy" do
     sign_in users(:user)
-    delete :destroy, { id: 1, locale: :en}
+    delete :destroy, id: 1, locale: :en
     assert_redirected_to root_path
   end
 
@@ -117,7 +117,7 @@ class Admin::CategoriesControllerTest < ActionController::TestCase
       # Ensure there are multiple locales
       AppSettings["i18n.available_locales"] = %w(en es fr)
 
-      get :edit, id: 1, locale: "en"
+      get :edit, id: 1, locale: :en
       assert_select "select#lang", 1
     end
 
@@ -155,20 +155,20 @@ class Admin::CategoriesControllerTest < ActionController::TestCase
 
     test "an #{admin} should be able to update an existing category" do
       sign_in users(admin.to_sym)
-      patch :update, { id: 1, category: {name: "some name" }, locale: :en }
+      patch :update, id: 1, category: { name: "some name" }, locale: :en
       assert_redirected_to admin_categories_path
     end
 
     test "an #{admin} attempting to update a category with invalid params re-renders the edit template" do
       sign_in users(admin.to_sym)
-      patch :update, { id: 1, category: {name: nil }, locale: :en }
+      patch :update, id: 1, category: { name: nil }, locale: :en
       assert_template :edit
     end
 
     test "an #{admin} should be able to add a new translation to an existing category" do
       sign_in users(admin.to_sym)
       assert_difference "Category.find(1).translations.count", 1 do
-        patch :update, { id: 1, category: {name: "some name" }, locale: :fr, lang: "fr" }
+        patch :update, id: 1, category: { name: "some name" }, locale: :fr, lang: "fr"
       end
     end
 

--- a/test/controllers/admin/docs_controller_test.rb
+++ b/test/controllers/admin/docs_controller_test.rb
@@ -39,22 +39,22 @@ class Admin::DocsControllerTest < ActionController::TestCase
   end
 
   test "a browsing user should not be able to load edit" do
-    get :edit, { id: 3, locale: :en }
+    get :edit, id: 3, locale: :en
     assert_redirected_to new_user_session_path
   end
 
   test "a browsing user should not be able to load create" do
-    post :create, doc: { title: "some name", body: "some body text", category_id: 1 }, locale: "en"
+    post :create, doc: { title: "some name", body: "some body text", category_id: 1 }, locale: :en
     assert_redirected_to new_user_session_path
   end
 
   test "a browsing user should not be able to load update" do
-    patch :update, { id: 1, doc: { title: "some name", body: "some body text", category_id: 1}, locale: "en" }
+    patch :update, id: 1, doc: { title: "some name", body: "some body text", category_id: 1 }, locale: :en
     assert_redirected_to new_user_session_path
   end
 
   test "a browsing user should not be able to load destroy" do
-    delete :destroy, { id: 3, locale: "en" }
+    delete :destroy, id: 3, locale: :en
     assert_redirected_to new_user_session_path
   end
 
@@ -68,28 +68,28 @@ class Admin::DocsControllerTest < ActionController::TestCase
 
   test "a signed in user should not be able to load edit" do
     sign_in users(:user)
-    get :edit, { id: 3, locale: :en}
+    get :edit, id: 3, locale: :en
     assert_redirected_to root_path
   end
 
   test "a signed in user should not be able to load create" do
     sign_in users(:user)
     assert_difference "Doc.count", 0 do
-      post :create, doc: {title: "some name", body: "some body text", category_id: 1}, locale: :en
+      post :create, doc: { title: "some name", body: "some body text", category_id: 1 }, locale: :en
     end
     assert_redirected_to root_path
   end
 
   test "a signed in user should not be able to load update" do
     sign_in users(:user)
-    patch :update, { id: 1, doc: {title: "some name", body: "some body text", category_id: 1}, locale: :en }
+    patch :update, id: 1, doc: { title: "some name", body: "some body text", category_id: 1 }, locale: :en
     assert_redirected_to root_path
   end
 
   test "a signed in user should not be able to load destroy" do
     sign_in users(:user)
     assert_difference "Doc.count", 0 do
-      delete :destroy, { id: 3, locale: :en }
+      delete :destroy, id: 3, locale: :en
     end
     assert_redirected_to root_path
   end
@@ -112,7 +112,7 @@ class Admin::DocsControllerTest < ActionController::TestCase
     test "an #{admin} should see a translate dropdown when there are multiple available_locales" do
       sign_in users(admin.to_sym)
       AppSettings["i18n.available_locales"] = %w(en es fr)
-      get :edit, id: 1, category_id: 1, locale: "en"
+      get :edit, id: 1, category_id: 1, locale: :en
       assert_select "select#lang", 1
     end
 
@@ -144,13 +144,13 @@ class Admin::DocsControllerTest < ActionController::TestCase
 
     test "an #{admin} should be able to update an article" do
       sign_in users(admin.to_sym)
-      patch :update, { id: 1, doc: { title: "some name", body: "some body text", category_id: 1 }, locale: :en }
+      patch :update, id: 1, doc: { title: "some name", body: "some body text", category_id: 1 }, locale: :en
       assert_redirected_to admin_category_path(Doc.find(1).category.id)
     end
 
     test "an #{admin} should be able to create a new translation via the update page" do
       sign_in users(admin.to_sym)
-      patch :update, { id: 1, doc: { title: "En Francais", body: "Ceci est la version française", category_id: 1 }, locale: :en, lang: :fr }
+      patch :update, id: 1, doc: { title: "En Francais", body: "Ceci est la version française", category_id: 1 }, locale: :en, lang: :fr
       assert_equal Doc.find(1).translations.count, 2
       assert_redirected_to admin_category_path(Doc.find(1).category.id)
     end

--- a/test/controllers/admin/forums_controller_test.rb
+++ b/test/controllers/admin/forums_controller_test.rb
@@ -32,22 +32,22 @@ class Admin::ForumsControllerTest < ActionController::TestCase
   end
 
   test "a browsing user should not get edit" do
-    get :edit, { id: 3, locale: :en }
+    get :edit, id: 3, locale: :en
     assert_redirected_to new_user_session_path
   end
 
   test "a browsing user should not get create" do
-    post :create, forum: {name: "some name", description: "some descrpition"}, locale: :en
+    post :create, forum: { name: "some name", description: "some description" }, locale: :en
     assert_redirected_to new_user_session_path
   end
 
   test "a browsing user should not get update" do
-    patch :update, { id: 3, forum: {name: "some name", description: "some descrpition"}, locale: :en }
+    patch :update, id: 3, forum: { name: "some name", description: "some description" }, locale: :en
     assert_redirected_to new_user_session_path
   end
 
   test "a browsing user should not get destroy" do
-    delete :destroy, { id: 3, locale: :en }
+    delete :destroy, id: 3, locale: :en
     assert_redirected_to new_user_session_path
   end
 
@@ -61,25 +61,25 @@ class Admin::ForumsControllerTest < ActionController::TestCase
 
     test "a #{unauthorized} should not get edit" do
       sign_in users(unauthorized.to_sym)
-      get :edit, { id: 3, locale: :en }
+      get :edit, id: 3, locale: :en
       assert_redirected_to root_path
     end
 
     test "a #{unauthorized} should not get create" do
       sign_in users(unauthorized.to_sym)
-      post :create, forum: {name: "some name", description: "some descrpition"}, locale: :en
+      post :create, forum: { name: "some name", description: "some description" }, locale: :en
       assert_redirected_to root_path
     end
 
     test "a #{unauthorized} should not get update" do
       sign_in users(unauthorized.to_sym)
-      patch :update, { id: 3, forum: {name: "some name", description: "some descrpition"}, locale: :en }
+      patch :update, id: 3, forum: { name: "some name", description: "some description" }, locale: :en
       assert_redirected_to root_path
     end
 
     test "a #{unauthorized} should not get destroy" do
       sign_in users(unauthorized.to_sym)
-      delete :destroy, { id: 3, locale: :en }
+      delete :destroy, id: 3, locale: :en
       assert_redirected_to root_path
     end
   end
@@ -100,13 +100,13 @@ class Admin::ForumsControllerTest < ActionController::TestCase
 
     test "an #{admin} should get create" do
       sign_in users(admin.to_sym)
-      post :create, forum: {name: "some name", description: "some descrpition"}, locale: :en
+      post :create, forum: { name: "some name", description: "some description" }, locale: :en
       assert_redirected_to admin_forums_path
     end
 
     test "an #{admin} should get update" do
       sign_in users(admin.to_sym)
-      patch :update, { id: 3, forum: {name: "some name", description: "some descrpition"}, locale: :en }
+      patch :update, id: 3, forum: { name: "some name", description: "some description" }, locale: :en
       assert_redirected_to admin_forums_path
     end
 

--- a/test/controllers/admin/groups_controller_test.rb
+++ b/test/controllers/admin/groups_controller_test.rb
@@ -15,6 +15,7 @@ class Admin::GroupsControllerTest < ActionController::TestCase
     set_default_settings
   end
 
+  # TODO: This looks like a duplicate test - should we remove the sign_in here?
   test "a signed out user should not be able to load the group page" do
     sign_in users(:user)
     get :index, locale: :en
@@ -35,7 +36,7 @@ class Admin::GroupsControllerTest < ActionController::TestCase
 
   test "an admin should be able to create new group with dummy tagging" do
     sign_in users(:admin)
-    params = {acts_as_taggable_on_tag: {name: "test_tag", show_on_helpcenter: true, show_on_admin: true, show_on_dashboard: true}}
+    params = { acts_as_taggable_on_tag: { name: "test_tag", show_on_helpcenter: true, show_on_admin: true, show_on_dashboard: true } }
     assert_difference "ActsAsTaggableOn::Tag.count", 1 do
       post :create, params
     end
@@ -45,14 +46,14 @@ class Admin::GroupsControllerTest < ActionController::TestCase
     sign_in users(:admin)
     tag = create(:acts_as_taggable_on_tag)
     assert_difference "ActsAsTaggableOn::Tag.count", -1 do
-      delete :destroy, { id: tag.id, locale: "en" }
+      delete :destroy, id: tag.id, locale: :en
     end
   end
 
   test "an admin should be able to update group" do
     sign_in users(:admin)
     tag = create(:acts_as_taggable_on_tag)
-    put :update, { id: tag.id, acts_as_taggable_on_tag: {show_on_admin: true}}
+    put :update, id: tag.id, acts_as_taggable_on_tag: { show_on_admin: true }
     assert_equal ActsAsTaggableOn::Tag.last.show_on_admin, true
   end
 

--- a/test/controllers/admin/onboarding_controller_test.rb
+++ b/test/controllers/admin/onboarding_controller_test.rb
@@ -50,7 +50,8 @@ class Admin::OnboardingControllerTest < ActionController::TestCase
         name: "something",
         email: "something@test.com",
         company: "company",
-        password: "12345678" }
+        password: "12345678"
+      }
     }
 
     user = User.find(1)

--- a/test/controllers/admin/posts_controller_test.rb
+++ b/test/controllers/admin/posts_controller_test.rb
@@ -25,7 +25,7 @@ class Admin::PostsControllerTest < ActionController::TestCase
     test "a #{unauthorized} should NOT be able to edit a post" do
       sign_in users(unauthorized.to_sym)
       original_post = Post.find(1)
-      xhr :patch, :update, { id: 1, post: { body: "this has changed" }, locale: :en}
+      xhr :patch, :update, id: 1, post: { body: "this has changed" }, locale: :en
       assert original_post.body == Post.find(1).body
       assert :success
     end
@@ -33,9 +33,9 @@ class Admin::PostsControllerTest < ActionController::TestCase
 
   %w(admin agent).each do |admin|
 
-    test "an #{admin} should be able to see inactive posts" do
-
-    end
+    # TODO
+    # test "an #{admin} should be able to see inactive posts" do
+    # end
 
     test "an #{admin} should be able to reply to a private topic, and the system should send an email" do
       sign_in users(admin.to_sym)

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -65,19 +65,19 @@ class Admin::SettingsControllerTest < ActionController::TestCase
       'design.footer_mini_logo' => 'logo2.png',
       'design.favicon' => 'favicon2.ico',
       'css.search_background' => '000000',
-      'css.top_bar' => '000000',
-      'css.link_color' => '000000',
-      'css.form_background' => '000000',
-      'css.still_need_help' => '000000'
+      'css.top_bar' => 'aaaaaa',
+      'css.link_color' => 'bbbbbb',
+      'css.form_background' => 'cccccc',
+      'css.still_need_help' => 'dddddd'
     assert_response :success
     assert_equal 'logo2.png', AppSettings['design.header_logo']
     assert_equal 'logo2.png', AppSettings['design.footer_mini_logo']
     assert_equal 'favicon2.ico', AppSettings['design.favicon']
     assert_equal '000000', AppSettings['css.search_background']
-    assert_equal '000000', AppSettings['css.top_bar']
-    assert_equal '000000', AppSettings['css.link_color']
-    assert_equal '000000', AppSettings['css.form_background']
-    assert_equal '000000', AppSettings['css.still_need_help']
+    assert_equal 'aaaaaa', AppSettings['css.top_bar']
+    assert_equal 'bbbbbb', AppSettings['css.link_color']
+    assert_equal 'cccccc', AppSettings['css.form_background']
+    assert_equal 'dddddd', AppSettings['css.still_need_help']
   end
 
   test 'an admin should be able to change the theme' do
@@ -146,27 +146,27 @@ class Admin::SettingsControllerTest < ActionController::TestCase
   test 'an admin should be able to add a cloudinary key' do
     sign_in users(:admin)
     xhr :put, :update_settings,
-      'cloudinary.cloud_name' => 'something',
-      'cloudinary.api_key' => 'something',
-      'cloudinary.api_secret' => 'something'
+      'cloudinary.cloud_name' => 'some_name',
+      'cloudinary.api_key' => 'some_key',
+      'cloudinary.api_secret' => 'some_secret'
     assert_response :success
-    assert_equal 'something', AppSettings['cloudinary.cloud_name']
-    assert_equal 'something', AppSettings['cloudinary.api_key']
-    assert_equal 'something', AppSettings['cloudinary.api_secret']
+    assert_equal 'some_name', AppSettings['cloudinary.cloud_name']
+    assert_equal 'some_key', AppSettings['cloudinary.api_key']
+    assert_equal 'some_secret', AppSettings['cloudinary.api_secret']
     get :index
   end
 
   test 'the updated cloudinary keys should be persisted into the api object' do
     sign_in users(:admin)
     xhr :put, :update_settings,
-      'cloudinary.cloud_name' => 'something',
-      'cloudinary.api_key' => 'something',
-      'cloudinary.api_secret' => 'something'
+      'cloudinary.cloud_name' => 'some_name',
+      'cloudinary.api_key' => 'some_key',
+      'cloudinary.api_secret' => 'some_secret'
     assert_response :success
     get :index
-    assert_equal 'something', Cloudinary.config.cloud_name
-    assert_equal 'something', Cloudinary.config.api_key
-    assert_equal 'something', Cloudinary.config.api_secret
+    assert_equal 'some_name', Cloudinary.config.cloud_name
+    assert_equal 'some_key', Cloudinary.config.api_key
+    assert_equal 'some_secret', Cloudinary.config.api_secret
   end
 
   test "an agent should be able to update their profile" do

--- a/test/controllers/admin/topics_controller_test.rb
+++ b/test/controllers/admin/topics_controller_test.rb
@@ -11,6 +11,7 @@ class Admin::TopicsControllerTest < ActionController::TestCase
   %w(admin agent).each do |admin|
 
     ### Topic split
+
     test "an #{admin} should be able to split a ticket" do
       sign_in users(admin.to_sym)
 
@@ -61,7 +62,6 @@ class Admin::TopicsControllerTest < ActionController::TestCase
       sign_in users(admin.to_sym)
 
       # Assign agent and topic to a group
-      agent = users(admin)
       topic = topics(:private)
       topic.current_status = "open"
       topic.team_list = "test"
@@ -139,9 +139,9 @@ class Admin::TopicsControllerTest < ActionController::TestCase
 
     ### tests of changing status
 
-    test "an #{admin} posting an internal note should not change status on its own" do
-
-    end
+    # TODO
+    # test "an #{admin} posting an internal note should not change status on its own" do
+    # end
 
     test "an #{admin} should be able to change an open ticket to closed" do
       sign_in users(admin.to_sym)
@@ -237,7 +237,6 @@ class Admin::TopicsControllerTest < ActionController::TestCase
 
     test "an #{admin} should be able to create a new private discussion for an existing user with an email" do
       sign_in users(admin.to_sym)
-      existing_user = users(:user)
       assert_difference "Topic.count", 1 do
         assert_difference "Post.count", 1 do
           xhr :post, :create, topic: { user: { name: "scott", email: "scott.miller@test.com" }, name: "some new private topic", post: { body: "this is the body" }, forum_id: 1 }
@@ -247,7 +246,6 @@ class Admin::TopicsControllerTest < ActionController::TestCase
 
     test "an #{admin} should be able to create a new private discussion for an existing user with a mixed case email" do
       sign_in users(admin.to_sym)
-      existing_user = users(:user)
       assert_difference "Topic.count", 1 do
         assert_difference "Post.count", 1 do
           xhr :post, :create, topic: { user: { name: "scott", email: "Scott.Miller@test.com" }, name: "some new private topic", post: { body: "this is the body" }, forum_id: 1 }
@@ -298,14 +296,14 @@ class Admin::TopicsControllerTest < ActionController::TestCase
 
     test "an #{admin} should be able to assign_team of a topic" do
       sign_in users(admin.to_sym)
-      xhr :get, :assign_team, { topic_ids: [1], team: "test"}
+      xhr :get, :assign_team, { topic_ids: [1], team: "test" }
       assert_equal ["test"], Topic.find(1).team_list
     end
 
     test "an #{admin} should be able to unassign_team of a topic" do
       Topic.find(1).team_list = "test"
       sign_in users(admin.to_sym)
-      xhr :get, :unassign_team, { topic_ids: [1]}
+      xhr :get, :unassign_team, { topic_ids: [1] }
       assert_equal [], Topic.find(1).team_list
     end
 
@@ -338,7 +336,7 @@ class Admin::TopicsControllerTest < ActionController::TestCase
     topic.team_list = "test"
     topic.save!
 
-    get :index, { status: "open" }
+    get :index, status: "open"
     assert_not_nil assigns(:topics)
     assert_equal 1, assigns(:topics).size
     assert_template "admin/topics/index"
@@ -358,7 +356,7 @@ class Admin::TopicsControllerTest < ActionController::TestCase
     topic.team_list = "aomething else"
     topic.save!
 
-    get :index, { status: "open" }
+    get :index, status: "open"
     assert_equal 0, assigns(:topics).size
     assert_template "admin/topics/index"
     assert_response :success
@@ -377,7 +375,7 @@ class Admin::TopicsControllerTest < ActionController::TestCase
     topic.team_list = "aomething else"
     topic.save!
 
-    get :show, { id: topic.id }
+    get :show, id: topic.id
     assert_template "admin/topics/show"
     assert_response 403
   end
@@ -387,7 +385,7 @@ class Admin::TopicsControllerTest < ActionController::TestCase
     test "an #{unauthorized} should NOT be able to see a list of topics via standard request" do
       sign_in users(unauthorized.to_sym)
 
-      get :index, { status: "open" }
+      get :index, status: "open"
       assert_nil assigns(:topics)
       assert_response :redirect
     end
@@ -395,7 +393,7 @@ class Admin::TopicsControllerTest < ActionController::TestCase
     test "an #{unauthorized} should NOT be able to see a specific topic of each type via standard request" do
       sign_in users(unauthorized.to_sym)
       [3,7].each do |topic_id|
-        get :show, { id: topic_id }
+        get :show, id: topic_id
         assert_nil assigns(:topic)
         assert_response :redirect
       end

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -81,14 +81,15 @@ class Admin::UsersControllerTest < ActionController::TestCase
 
     test "an #{admin} should be able to see a filtered of users" do
       sign_in users(admin.to_sym)
-      get :index, { role: 'user' }
+      get :index, role: 'user'
       assert_equal 4, assigns(:users).count
     end
 
     test "an #{admin} should be able to update a user" do
       sign_in users(admin.to_sym)
-      patch :update, {
-        id: 6, user: {
+      patch :update,
+        id: 6, 
+        user: {
           name: "something",
           email:"scott.miller2@test.com",
           zip: '9999',
@@ -100,7 +101,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
           password: '11223344',
           password_confirmation: '11223344',
         },
-        locale: :en }
+        locale: :en 
       u = User.find(6)
 
       # assert values changed
@@ -121,11 +122,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
       user_before_update.team_list = "one"
       user_before_update.save
 
-      patch :update, {
-        id: 6, user: {
-          name: "something else"
-        },
-        locale: :en }
+      patch :update, id: 6, user: { name: "something else" }, locale: :en
 
       u = User.find(6)
       assert u.name == "something else", "name does not update"
@@ -158,7 +155,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
   test "an admin should be able to update a user and make them an admin" do
     sign_in users(:admin)
     assert_difference("User.admins.count", 1) do
-      patch :update, {id: 2, user: {name: "something", email:"scott.miller@test.com", role: 'admin'}, locale: :en}
+      patch :update, id: 2, user: { name: "something", email:"scott.miller@test.com", role: 'admin' }, locale: :en
     end
   end
 
@@ -177,7 +174,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
     test "an #{unauthorized} should NOT be able to update a user and change their role" do
       sign_in users(unauthorized.to_sym)
       assert_difference("User.admins.count", 0) do
-        patch :update, {id: 2, user: {name: "something", email:"scott.miller@test.com", role: "agent"}, locale: :en}
+        patch :update, id: 2, user: { name: "something", email:"scott.miller@test.com", role: "agent" }, locale: :en
       end
     end
   end

--- a/test/integration/admin_settings_flows_test.rb
+++ b/test/integration/admin_settings_flows_test.rb
@@ -23,7 +23,7 @@ class AdminSettingsFlowsTest < ActionDispatch::IntegrationTest
     fill_in('settings.site_name', with: 'xyz')
     fill_in('settings.parent_site', with: 'parent_xyz.com')
     fill_in('settings.parent_company', with: 'parent_xyz')
-    click_on 'Save Settings'
+    click_on I18n.t(:save_settings)
 
     visit('/en')
     sleep(1)
@@ -44,7 +44,7 @@ class AdminSettingsFlowsTest < ActionDispatch::IntegrationTest
     check('English')
     check('Español')
     check('Deutsch')
-    click_on 'Save Settings'
+    click_on I18n.t(:save_settings)
 
     visit('/en/locales/select')
     sleep(1)
@@ -66,7 +66,7 @@ class AdminSettingsFlowsTest < ActionDispatch::IntegrationTest
 
     fill_in('design.header_logo', with: '/uploads/logos/logo-test.png')
     fill_in('design.favicon', with: '/uploads/logos/favicon-test.ico')
-    click_on 'Save Settings'
+    click_on I18n.t(:save_settings)
 
     visit('/en')
     sleep(1)

--- a/test/integration/admin_settings_flows_test.rb
+++ b/test/integration/admin_settings_flows_test.rb
@@ -17,12 +17,12 @@ class AdminSettingsFlowsTest < ActionDispatch::IntegrationTest
 
   test 'an admin should be able to modify site settings and see those changes on the support site' do
     visit('/admin/settings/general')
-    assert page.has_content?('Settings'), 'Missing header'
+    assert page.has_content?(I18n.t(:settings)), 'Missing header'
 
     # Now make changes to all settings from defaults and make sure those changes are on the live site
     fill_in('settings.site_name', with: 'xyz')
-    fill_in('settings.parent_site', with: 'xyz')
-    fill_in('settings.parent_company', with: 'xyz')
+    fill_in('settings.parent_site', with: 'parent_xyz.com')
+    fill_in('settings.parent_company', with: 'parent_xyz')
     click_on 'Save Settings'
 
     visit('/en')
@@ -30,7 +30,7 @@ class AdminSettingsFlowsTest < ActionDispatch::IntegrationTest
     within('a.navbar-brand') do
       assert page.has_content?('xyz')
     end
-    assert page.has_content?('Back to xyz')
+    assert page.has_content?("#{I18n.t(:back_to)} parent_xyz")
 
     # TODO: Figure out how to test the change of GA token
   end
@@ -38,7 +38,7 @@ class AdminSettingsFlowsTest < ActionDispatch::IntegrationTest
   test 'an admin should be able to enable or disable i18n and be able to browse to those locales on the site' do
     visit('/admin/settings/i18n')
 
-    assert page.has_content?('Settings'), 'Missing header'
+    assert page.has_content?(I18n.t(:settings)), 'Missing header'
 
     # Now make changes to all settings from defaults and make sure those changes are on the live site
     check('English')
@@ -62,7 +62,7 @@ class AdminSettingsFlowsTest < ActionDispatch::IntegrationTest
   test 'an admin should be able to alter the logo images used' do
     visit('/admin/settings/design')
 
-    assert page.has_content?('Design'), 'Missing header'
+    assert page.has_content?(I18n.t(:design)), 'Missing header'
 
     fill_in('design.header_logo', with: '/uploads/logos/logo-test.png')
     fill_in('design.favicon', with: '/uploads/logos/favicon-test.ico')

--- a/test/integration/browsing_user_doc_flows_test.rb
+++ b/test/integration/browsing_user_doc_flows_test.rb
@@ -19,9 +19,9 @@ class BrowsingUserDocFlowsTest < ActionDispatch::IntegrationTest
     create_some_comments
     visit '/en/knowledgebase/1-active-and-featured/docs/6-allows-comments'
     assert page.has_content?('test post')
-    assert page.has_content?('Reply')
+    assert page.has_content?(I18n.t(:reply))
 
-    click_on "Reply"
+    click_on I18n.t(:reply)
     assert find("div#login-modal").visible?
 
     clear_comments
@@ -29,15 +29,15 @@ class BrowsingUserDocFlowsTest < ActionDispatch::IntegrationTest
 
   test "when a doc allows commenting and there are no comments, a browsing user should see a start discussion button" do
     visit '/en/knowledgebase/1-active-and-featured/docs/6-allows-comments'
-    assert page.has_content?('Start a Discussion')
+    assert page.has_content?(I18n.t(:start_discussion))
 
-    click_on "Start a Discussion"
+    click_on I18n.t(:start_discussion)
     assert find("div#login-modal").visible?
   end
 
   test "when a doc does not allow commenting, a browsing user should not see a reply button" do
     visit '/en/knowledgebase/1-active-and-featured/docs/5-does-not-allow-comments'
-    assert page.has_no_content?('Start a New Discussion')
+    assert page.has_no_content?(I18n.t(:start_discussion))
   end
 
   def create_some_comments

--- a/test/integration/browsing_user_ticket_flows_test.rb
+++ b/test/integration/browsing_user_ticket_flows_test.rb
@@ -31,7 +31,7 @@ class BrowsingUserTicketFlowsTest < ActionDispatch::IntegrationTest
         fill_in('topic[user][name]', with: 'John Smith')
         fill_in('topic[name]', with: 'I got problems')
         fill_in('topic[posts_attributes][0][body]', with: 'Please help me!!')
-        click_on('Create Ticket', disabled: true)
+        click_on(I18n.t(:submit_start_discussion), disabled: true)
       end
     end
     assert current_path == '/en/thanks'
@@ -55,7 +55,7 @@ class BrowsingUserTicketFlowsTest < ActionDispatch::IntegrationTest
         fill_in('topic[user][name]', with: 'John Smith')
         fill_in('topic[name]', with: 'I got problems')
         fill_in('topic[posts_attributes][0][body]', with: 'Please help me!!')
-        click_on('Create Ticket', disabled: true)
+        click_on(I18n.t(:submit_start_discussion), disabled: true)
       end
     end
     assert current_path == "/en/topics/#{Topic.last.id}-i-got-problems/posts"
@@ -74,7 +74,7 @@ class BrowsingUserTicketFlowsTest < ActionDispatch::IntegrationTest
         fill_in('topic[user][name]', with: 'Scott Miller')
         fill_in('topic[name]', with: 'I got problems')
         fill_in('topic[posts_attributes][0][body]', with: 'Please help me!!')
-        click_on('Create Ticket', disabled: true)
+        click_on(I18n.t(:submit_start_discussion), disabled: true)
       end
     end
 
@@ -88,9 +88,10 @@ class BrowsingUserTicketFlowsTest < ActionDispatch::IntegrationTest
 
     forums.each do |forum|
       visit forum
-      click_on "Start a Discussion"
+      click_on I18n.t(:start_discussion)
       assert find("div#login-modal").visible?
     end
+
   end
 
   test "a browsing user should be prompted to login when clicking reply from a public discussion view" do
@@ -101,9 +102,10 @@ class BrowsingUserTicketFlowsTest < ActionDispatch::IntegrationTest
 
     topics.each do |topic|
       visit topic
-      click_on "Reply"
+      click_on I18n.t(:reply)
       assert find("div#login-modal").visible?
     end
+
   end
 
   test "a browsing user should be able to create a private ticket via widget" do
@@ -115,16 +117,15 @@ class BrowsingUserTicketFlowsTest < ActionDispatch::IntegrationTest
       fill_in('topic_user_name', with: 'Joe Guy')
       fill_in('topic[name]', with: 'I got problems')
       fill_in('topic[posts_attributes][0][body]', with: 'Please help me!!')
-      click_on('Create Ticket', disabled: true)
+      click_on(I18n.t(:submit_start_discussion), disabled: true)
     end
 
   end
 
   test "a browsing user should be prompted to login when clicking flag for review from a public discussion view" do
     visit '/en/topics/5-new-public-topic/posts'
-    click_on "Flag for Review"
+    click_on I18n.t(:flag_for_review)
     assert find("div#login-modal").visible?
   end
-
 
 end

--- a/test/integration/forum_voting_test.rb
+++ b/test/integration/forum_voting_test.rb
@@ -33,29 +33,29 @@ class SignedInUserTicketFlowsTest < ActionDispatch::IntegrationTest
     visit "/en/community/4-public-idea-board/topics"
     assert_difference('Topic.find(8).points') do
       within first('div#post-vote-8') do
-        click_link "Upvote | 0"
+        click_link I18n.t('upvote.other', count: '0')
       end
     end
     visit "/en/community/4-public-idea-board/topics"
     within first('a.topic-vote') do
-      assert page.has_content?("Upvote | 1")
+      assert page.has_content? I18n.t('upvote.one', count: '1')
     end
 
 
     visit "/en/community/5-public-q-a/topics"
     assert_difference('Topic.find(7).points') do
       within first('div#post-vote-7') do
-        click_link "Upvote | 0"
+        click_link I18n.t('upvote.other', count: '0')
       end
     end
     visit "/en/community/5-public-q-a/topics"
     within first('div#post-vote-7') do
-      assert page.has_content?("Upvote | 1")
+      assert page.has_content? I18n.t('upvote.one', count: '1')
     end
   end
 
-  test "a logged in user should be able to vote on a reply from the topic detail view" do
-
-  end
+  # TODO
+  # test "a logged in user should be able to vote on a reply from the topic detail view" do
+  # end
 
 end

--- a/test/integration/search_flows_test.rb
+++ b/test/integration/search_flows_test.rb
@@ -1,6 +1,5 @@
 require 'integration_test_helper'
 
-
 class SearchFlowsTest < ActionDispatch::IntegrationTest
 
   def setup

--- a/test/integration/sign_in_flow_test.rb
+++ b/test/integration/sign_in_flow_test.rb
@@ -16,7 +16,7 @@ class SignInFlowTest < ActionDispatch::IntegrationTest
   def sign_out
     visit '/'
     within("div#above-header") do
-      click_on("Logout")
+      click_on I18n.t(:logout)
     end
   end
 

--- a/test/integration/signed_in_user_doc_flows_test.rb
+++ b/test/integration/signed_in_user_doc_flows_test.rb
@@ -21,11 +21,11 @@ class SignedInUserDocFlowsTest < ActionDispatch::IntegrationTest
     create_some_comments
     visit '/en/knowledgebase/1-active-and-featured/docs/6-allows-comments'
     assert page.has_content?('test post')
-    assert page.has_content?('Reply')
+    assert page.has_content?(I18n.t(:reply))
     assert page.has_css?("div.add-form")
 
     fill_in('post_body', with: "Added a comment!")
-    click_on('Post Reply', disabled: true)
+    click_on(I18n.t(:submit_reply), disabled: true)
 
     assert page.has_content?('Added a comment!')
 
@@ -35,11 +35,11 @@ class SignedInUserDocFlowsTest < ActionDispatch::IntegrationTest
   test "when a doc allows commenting and there are no comments, a signed in user should see a start discussion form" do
 
     visit '/en/knowledgebase/1-active-and-featured/docs/6-allows-comments'
-    assert page.has_content?('Start a Discussion')
+    assert page.has_content?(I18n.t(:start_discussion))
     assert page.has_css?("div.add-form")
 
     fill_in('post_body', with: "Added a comment!")
-    click_on('Start a Discussion', disabled: true)
+    click_on(I18n.t(:start_discussion), disabled: true)
 
     assert page.has_content?('Added a comment!')
 
@@ -48,8 +48,8 @@ class SignedInUserDocFlowsTest < ActionDispatch::IntegrationTest
   test "when a doc does not allow commenting, a signed in user should not see a reply or start discussion button" do
 
     visit '/en/knowledgebase/1-active-and-featured/docs/5-does-not-allow-comments'
-    assert page.has_no_content?('Start a New Discussion')
-    assert page.has_no_content?('Reply')
+    assert page.has_no_content?(I18n.t(:start_discussion))
+    assert page.has_no_content?(I18n.t(:reply))
     assert page.has_no_css?("div.add-form")
 
   end

--- a/test/integration/signed_in_user_ticket_flows_test.rb
+++ b/test/integration/signed_in_user_ticket_flows_test.rb
@@ -21,17 +21,17 @@ class SignedInUserTicketFlowsTest < ActionDispatch::IntegrationTest
     visit '/en'
     visit '/en/topics/new/'
 
-    assert page.has_content?('Should this message be private?')
+    assert page.has_content?(I18n.t(:should_message_be_private))
 
     assert_difference('Topic.count', 1) do
-      choose('Only support can respond (creates a private ticket)')
+      choose(I18n.t(:only_support_can_respond))
       fill_in('topic[name]', with: 'I got problems')
       fill_in('topic[posts_attributes][0][body]', with: 'Please help me!!')
-      click_on('Create Ticket', disabled: true)
+      click_on(I18n.t(:submit_start_discussion), disabled: true)
     end
 
     visit '/en/tickets/'
-    assert page.has_content?('Tickets')
+    assert page.has_content?(I18n.t(:tickets))
     assert page.has_content?("##{Topic.last.id}- I got problems")
 
   end
@@ -43,14 +43,14 @@ class SignedInUserTicketFlowsTest < ActionDispatch::IntegrationTest
     visit '/en'
     visit '/en/topics/new/'
 
-    assert page.has_content?('Should this message be private?')
+    assert page.has_content?(I18n.t(:should_message_be_private))
 
     assert_difference('Topic.count', 1) do
-      choose('Responses can come from support or the community (recommended)')
+      choose(I18n.t(:responses_can_come_from_everyone))
       select('Public Forum', from: "topic[forum_id]")
       fill_in('topic[name]', with: 'I got problems')
       fill_in('topic[posts_attributes][0][body]', with: 'Please help me!!')
-      click_on('Create Ticket', disabled: true)
+      click_on(I18n.t(:submit_start_discussion), disabled: true)
     end
 
     visit '/en/community/3-public-forum/topics'
@@ -71,7 +71,7 @@ class SignedInUserTicketFlowsTest < ActionDispatch::IntegrationTest
     assert current_path == '/en/ticket/1-private-topic'
     assert_difference('Post.count', 1) do
       fill_in "post_body", with: "This is my reply"
-      click_on "Post Reply", disabled: true
+      click_on I18n.t(:submit_reply), disabled: true
     end
 
 #    assert page.has_content?('This is my reply'), "Reply not found"
@@ -88,7 +88,7 @@ class SignedInUserTicketFlowsTest < ActionDispatch::IntegrationTest
 
     forums.each do |forum|
       visit forum
-      click_on "Start a Discussion"
+      click_on I18n.t(:start_discussion)
       assert current_path == "/en/topics/new"
     end
 
@@ -124,7 +124,7 @@ class SignedInUserTicketFlowsTest < ActionDispatch::IntegrationTest
 
       assert_difference('Post.count', 1) do
         fill_in "post_body", with: "This is my reply"
-        click_on "Post Reply"
+        click_on I18n.t(:submit_reply)
       end
 
       visit topic
@@ -143,11 +143,11 @@ class SignedInUserTicketFlowsTest < ActionDispatch::IntegrationTest
     assert_difference('Post.count', 1) do
       fill_in('topic[name]', with: 'I got problems')
       fill_in('topic[posts_attributes][0][body]', with: 'Please help me!!')
-      click_on('Create Ticket', disabled: true)
+      click_on(I18n.t(:submit_start_discussion), disabled: true)
     end
 
     visit '/en/tickets/'
-    assert page.has_content?('Tickets')
+    assert page.has_content?(I18n.t(:tickets))
     assert page.has_content?("##{Topic.last.id}- I got problems")
 
   end
@@ -156,7 +156,7 @@ class SignedInUserTicketFlowsTest < ActionDispatch::IntegrationTest
     sign_in
 
     visit '/en/topics/5-new-public-topic/posts'
-    click_on "Flag for Review"
+    click_on I18n.t(:flag_for_review)
     assert find("div#flag-modal").visible?
   end
 

--- a/test/integration/signed_in_user_ticket_flows_test.rb
+++ b/test/integration/signed_in_user_ticket_flows_test.rb
@@ -105,7 +105,7 @@ class SignedInUserTicketFlowsTest < ActionDispatch::IntegrationTest
     topics.each do |topic|
       visit topic
       assert page.has_no_css?('#reply-button'), message: "Reply button displayed when it shouldnt be (url: #{topic})"
-      assert page.has_content?('Type your response:')
+      assert page.has_content?(I18n.t(:type_response))
     end
 
   end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -11,18 +11,18 @@ def sign_in(email='scott.miller@test.com')
   within first('div.login-form') do
     fill_in("user[email]", with: email)
     fill_in("user[password]", with: '12345678')
-    click_on('Sign in')
+    click_on(I18n.t('devise.sessions.new.sign_in'))
   end
 end
 
 def sign_in_by_modal(email='scott.miller@test.com')
   within("div#above-header") do
-    click_on "Sign in", wait: 30
+    click_on I18n.t('devise.sessions.new.sign_in'), wait: 30
   end
   within('div#login-modal') do
     fill_in("user[email]", with: email)
     fill_in("user[password]", with: '12345678')
-    click_on('Sign in')
+    click_on(I18n.t('devise.sessions.new.sign_in'))
   end
 end
 

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -149,5 +149,4 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_equal notification.bcc, []
   end
 
-
 end


### PR DESCRIPTION
Closes #497 by using I18n strings in tests - mostly integration specs, though I did go through the other specs looking for easy wins. :) 

As I was reading through I did a little cleanup as well, including standardizing hash syntax & TODO'ing empty test blocks. I've isolated these syntactic changes in a separate commit if you'd prefer them as a separate MR or don't want them at all.

I added one note on a test I wasn't 100% sure of: https://github.com/helpyio/helpy/compare/master...ATMartin:497-prefer-i18n-in-tests?expand=1#diff-748cb53bc2fea4dda7fb4b8d57ef9bc3R19
Let me know if I'm thinking correctly and I can clean that up as well before merge. 

Thanks!