### PR TITLE
remove "flat" namespace from flat locale

### DIFF
--- a/app/themes/flat/locales/en.yml
+++ b/app/themes/flat/locales/en.yml
@@ -1,283 +1,459 @@
+# MAINTAINER: SCOTT MILLER
+
 en:
-  flat:
-    language_name: 'English' # The name of the translation file, in that language
-    root: &root 'Home'
-    how_can_we_help: "Search our Knowledgebase"
-    browse_topics: "Browse Topics"
-    support_team: "Support Team"
-    nothing_here: "Nothing here yet!"
+  language_name: 'English' # The name of the translation file, in that language
+  root: &root 'Home'
+  how_can_we_help: "How can we help?"
+  browse_topics: "Browse Knowledgebase"
+  support_team: "Support Team"
+  nothing_here: "Nothing here yet!"
 
-    # Navigation
-    knowledgebase: "Knowledgebase"
-    community: "Community"
-    ask_a_question: "Ask a Question"
-    home: "Home"
-    login: "Login"
-    logout: "Logout"
-    register: "Register"
-    back_to: "Back to"
-    welcome_back: "Welcome Back %{username}"
-    your_profile: "Your Profile"
-    your_tickets: "Your Tickets"
-    locale: "Locale"
-    change_your_locale: "Change your Locale"
+  # Navigation
+  knowledgebase: "Knowledgebase"
+  community: "Community"
+  ask_a_question: "Open a Ticket"
+  home: "Home"
+  login: "Login"
+  logout: "Logout"
+  register: "Register"
+  back_to: "Back to"
+  welcome_back: "Welcome Back %{username}"
+  your_profile: "Your Profile"
+  your_tickets: "Your Tickets"
+  locale: "Locale"
+  change_your_locale: "Change your Locale"
 
-    # Voting widget
-    did_this_help: "Did this solve your problem?"
-    yes_button: 'Yes'
-    no_button: 'No'
-    yes_helped: 'Great!! Thanks for the feedback!'
-    no_helped: "We're sorry this didn't help you.  Please contact us for more help!"
+  # Voting widget
+  did_this_help: "Did this solve your problem?"
+  yes_button: 'Yes'
+  no_button: 'No'
+  yes_helped: 'Great! Thanks for the feedback!'
+  no_helped: "We're sorry this didn't help you.  Please contact us for more help!"
 
-    # Search
-    search_placeholder: "Enter a keyword, topic, or question"
-    no_results: "No Results Found, Please try your search again!"
-    results_found:
-      one: "one result found for your search "
-      other: "%{count} results found for your search "
+  # Search
+  search_placeholder: "Enter a keyword, topic, or question"
+  no_results: "No Results Found, Please try your search again!"
+  results_found:
+    one: "one result found for your search "
+    other: "%{count} results found for your search "
 
-    # Community
-    forum_name: "Topic"
-    subject: "Subject"
-    last_activity: "Last Active"
-    topic: "Discussion"
-    replies: "Replies"
-    last_post: "Last Post"
-    started_by: "Started by %{username}"
-    reply: "Reply to this topic"
-    submit_reply: "Post Reply"
-    posted: "Posted"
-    start_discussion: "Start a New Discussion"
-    submit_start_discussion: "Start Discussion"
-    should_message_be_private: "Should this message be private?"
-    only_support_can_respond: "Only support can respond (creates a private ticket)"
-    responses_can_come_from_everyone: "Responses can come from support or the community (recommended)"
-    collapsed_messages:
-        one: "1 collapsed message"
-        two: "2 collapsed messages"
-        other: "%{count} collapsed messages"
+  # Community
+  forum_name: "Topic"
+  subject: "Subject"
+  last_activity: "Last Active"
+  topic: "Discussion"
+  replies: "Replies"
+  last_post: "Last Post"
+  started_by: "Started by %{username}"
+  reply: "Reply to this ticket"
+  submit_reply: "Post Reply"
+  posted: "Posted"
+  start_discussion: "Start a Discussion"
+  submit_start_discussion: "Create Ticket"
+  should_message_be_private: "Should this message be private?"
+  only_support_can_respond: "Only support can respond (creates a private ticket)"
+  responses_can_come_from_everyone: "Responses can come from support or the community (recommended)"
+  collapsed_messages:
+      one: "1 collapsed message"
+      two: "2 collapsed messages"
+      other: "%{count} collapsed messages"
 
-    # Knowledgebase
-    written_by: "Written By"
-    last_edited: "Last Edited"
+  # Knowledgebase
+  written_by: "Written By"
+  last_edited: "Last Edited"
+  asked_before: "Has your question been answered before? We think these may be similar"
 
-    # Tickets
-    tickets: "Tickets"
-    no_tickets: "You have not created any tickets yet"
-    ticket_number: "Ticket Number"
-    assigned_to_label: "Assigned to"
-    created_on: "Created on"
+  # Tickets
+  tickets: "Tickets"
+  no_tickets: "You have not created any tickets yet"
+  ticket_number: "Ticket Number"
+  assigned_to_label: "Assigned to"
+  created_on: "Created on"
 
-    # Get Help
-    get_help_header: "Still Need Help?"
-    get_help_button: "Start a Discussion with Us"
+  # Get Help
+  get_help_header: "Still Need Help?"
+  get_help_button: "Open a ticket"
 
-    # Profile
-    my_profile: 'My Profile'
+  # Profile
+  my_profile: 'My Profile'
 
-    # footer
-    powered_by: "Powered by Helpy. An Open Source Helpdesk."
-    get_your_copy: "Grab your copy on GitHub"
+  # footer
+  powered_by: "Powered by Helpy. An Open Source Helpdesk."
+  get_your_copy: "Grab your copy on GitHub"
+  version: "Version:"
 
-    # devise/sessions/new
-    login: Log in
+  # flag
+  flag_for_review: "Flag for Review"
+  flag_post_for_review: "Flag Post for Review"
+  flag_post_placeholder: "Describe the reason for flagging this post"
+  flag: "Flag"
 
-    # devise/shared/links
-    forgot_password: Forgot your password?
+  # devise/sessions/new
+  login: Log in
 
-    # devise/passwords/new
-    send_instructions: Send me instructions
+  # devise/shared/links
+  forgot_password: Forgot your password?
 
-    # devise/passwords/edit
-    change_password: Change password
-    new_password: New password
-    new_password_confirmation: Confirm new password
+  # devise/passwords/new
+  send_instructions: Send me instructions
 
-    # devise/confirmations/new
-    resend: Resend confirmation instructions
+  # devise/passwords/edit
+  change_password: Change password
+  new_password: New password
+  new_password_confirmation: Confirm new password
 
-    # devise/registrations/new
-    sign_up: Sign Up
+  # devise/confirmations/new
+  resend: Resend confirmation instructions
 
-    # Admin menu
-    discussions: Discussions
-    content: Content
-    communities: Communities
-    app_store: App Store
-    search: Search
+  # devise/registrations/new
+  sign_up: Sign Up
 
-    # Admin main/statuses
-    support_pipeline: Support Pipeline
-    new: New
-    active: Active
-    open: Open
-    mine: Mine
-    pending: Pending
-    closed: Resolved
-    spam: Spam
-    trash: Trash
-    discussion_managment: Discussion Management
-    open_new_discussion: New Discussion
-    assigned_to: "assigned to %{agent}"
-    unassigned: unassigned
-    private: private
-    public: public
-    save_changes: Save Changes
+  # Admin menu
+  discussions: Tickets
+  content: Content
+  communities: Communities
+  app_store: App Store
+  search: Search
+  internal_content: Internal Content
 
-    # Discussion controls
-    change_status: Change Status
-    status: Status
-    mark_closed: Mark Resolved
-    reopen: Reopen
-    mark_spam: Mark Spam
-    mark_new: Mark New
-    assign_agent: Assign Agent
-    selected_messages:
-      one: "1 selected message"
-      two: "2 selected messages"
-      other: "%{count} selected messages"
+  # Admin main/statuses
+  support_pipeline: Support Pipeline
+  new: New
+  active: Active
+  open: Open
+  mine: Mine
+  pending: Pending
+  closed: Resolved
+  spam: Spam
+  trash: Trash
+  discussion_managment: Ticket Management
+  open_new_discussion: New Ticket
+  assigned_to: "assigned to %{agent}"
+  unassigned: unassigned
+  no_team_assigned: Assign to group
+  assign_to: Group/Team
+  unassign_from_team: Unassign from group
+  private: private
+  public: public
+  save_changes: Save Changes
+  merge: Merge
+  merge_confirm: Are you sure you want to merge these tickets?
 
-    # Discussion messages
-    reopen_message: "This message has been reopened by the support staff"
-    closed_message: "This ticket has been closed by the support staff."
-    trash_message: "This ticket has been deleted."
-    assigned_message: "Discussion has been transferred to %{assigned_to}."
+  # Discussion controls
+  change_status: Change Status
+  status: Status
+  mark_closed: Mark Resolved
+  reopen: Reopen
+  mark_spam: Mark Spam
+  mark_new: Mark New
+  assign_agent: Assign Agent
+  tag_with: Tag Ticket
+  selected_messages:
+    one: "1 selected message"
+    two: "2 selected messages"
+    other: "%{count} selected messages"
 
-    # User Admin
-    contact_info: Contact
-    social_info: Social
-    edit_user: Edit User
-    work_phone: work
-    cell_phone: cell
+  # Discussion messages
+  reopen_message: "This message has been reopened by the support staff"
+  closed_message: "This ticket has been closed by the support staff."
+  trash_message: "This ticket has been deleted."
+  assigned_message: "This ticket has been transferred to %{assigned_to}."
+  assigned_group: "This ticket has been assigned to %{assigned_group}."
+  converted_to_ticket: "This discussion was converted to a private ticket."
+  converted_to_topic: "This ticket was converted to an open discussion and moved to %{forum_name}."
+  tagged_with: "This ticket was tagged with %{tagged_with}"
+  notes_hidden: "There are %{hidden_notes} internal notes for this ticket. You can view them by clicking anywhere in this note!"
 
-    # User search results
-    users_found:
-      one: "1 user was found named %{query}"
-      other: "%{count} users were found named %{query}"
+  # User Admin
+  users: Users
+  account: Account
+  contact_info: Contact
+  social_info: Social
+  edit_user: Edit User
+  work_phone: work
+  cell_phone: cell
 
-    # Discussion View
-    asked_a_question: "%{user_name} asked a question..."
-    replied: "%{user_name} replied..."
-    posted_note: "%{user_name} posted an internal note..."
-    type_reply: Type your reply, or select from a common message below
-    select_common: Select Common Reply
-    reply: Reply
-    internal_note: Internal Note
-    upvote:
-      one: "Upvote | %{count}"
-      other: "Upvote | %{count}"
+  # Priorities
+  select_priority: Select Priority
+  vip_priority: VIP
+  high_priority: High
+  normal_priority: Normal
+  low_priority: Low
 
-    # Content
-    new_category: New Category
-    new_content: New Content
-    front_page_categories: Front Page Categories
-    other_categories: Other Categories
-    edit: Edit
-    edit_category: Edit Category
-    select_category: Select Category
-    delete: Delete
-    view_and_edit: "View and Edit Content"
-    delete_confirm: "Please confirm you want to DELETE this!"
-    select_icon_helptext: "Select an icon to associate with this category (optional)"
-    translate: "Translate to a different language"
-    view_on_site: "View on Site"
-    written_on: "Written on %{date_written}"
-    content_last_updated: "Last Updated on %{date_updated}"
-    featured_content: "Featured"
-    draft_content: "Draft"
-    published_content: "Published"
-    additional_settings: "Additional Settings"
-    content_status: "Content Status"
+  # Roles
+  select_role: Select Role
+  admin_role: Admin
+  agent_role: Agent
+  editor_role: Editor
+  user_role: Customer
+  add_more_agents: "Add more users"
 
-    # Communities
-    new_community: Create New Community
-    create_new_community: Create New Community
+  # Keyboard Shortcuts
+  shortcut_then: "then"
+  listing_views: "Listing views"
+  keyboard_shortcuts: "Keyboard Shortcuts"
+  show_new_tickets: "Show new tickets"
+  show_all_tickets: "Show all tickets"
+  show_open_tickets: "Show open tickets"
+  show_tickets_assigned_to_you: "Show tickets assigned to you"
+  show_pending_tickets_assigned_to_you: "Show pending tickets assigned to you"
+  show_closed_tickets: "Show closed tickets"
+  search_for_tickets: "Search for tickets"
+  viewing_tickets: "View tickets"
+  select_previous_ticket: "Select previous ticket"
+  select_next_ticket: "Select next ticket"
+  view_selected_ticket: "View selected ticket"
+  jump_to_a_specific_ticket_number: "Jump to a specific ticket number"
+  ticket_actions: "Ticket actions"
+  assign_the_ticket: "Assign ticket"
+  move_the_ticket: "Move ticket"
+  expand_the_ticket_thread: "Expand ticket thread"
+  reply_to_the_ticket: "Reply to the ticket"
+  add_an_internal_note: "Add an internal note"
+  change_ticket_status: "Change ticket status"
+  associate_with_a_group: "Associate with a group"
+  ticket_status: "Ticket status"
+  mark_resolved: "Mark as resolved"
+  reopen_ticket: "Reopen ticket"
+  set_to_new: "Mark as new"
+  mark_as_spam: "Mark as spam"
+  move_to_trash: "Move to trash"
+  ticket_number: "ticket number"
 
-    # Mail messages
-    hello: "Hello %{user_name}"
-    new_user: "Thank you for contacting us.  Your message has been received by our support team and we will be in touch with you shortly with a response."
-    account_generated: "An account has been generated for you. To sign in, please use this link:"
-    above_this_line: "Make sure your reply appears above this line"
-    message_id: "Message ID"
-    message_response: "The following message has been posted in response to your question:"
-    view_online: "View this online:"
+  # User search results
+  users_found:
+    one: "1 user was found named %{query}"
+    other: "%{count} users were found named %{query}"
 
-    # settings
-    settings: "Settings"
-    general: "General"
-    design: "Design"
-    international: "International"
-    widget: "Embeddable Widget"
+  # Invite users
+  invite_users: "Invite New Users"
+  invite_emails: "Email Addresses"
+  invite_emails_placeholder: "Type one or more email addresses to send an invitation to"
+  invite_message: "Message"
+  invite_message_placeholder: "An optional message that will be sent to the new users"
+  invite_role: "Role for Invited Users"
+  send_invite: "Send Invite"
 
-    activerecord:
-      attributes:
-        user:
-          email: Email
-          password: Password
-          name: Name
-          company: Company
-          work_phone: Work
-          cell_phone: Cell
-          city: City
-          state: State
-        topic:
-          name: Subject
-        post:
-          kind: Genre
-        category:
-          name: Name
-          icon: Icon
-          keywords: Keywords
-          title_tag: Title Tag
-          meta_description: Meta Description
-          front_page: Front Page
-          active: Active
-        doc:
-          title: Title
-          meta_description: Meta Description
-          title_tag: Title Tag
-          keywords: Keywords
-          category_id: Category
-          active: Status
-          front_page: Featured on front page?
-        forum:
-          name: Name
-          description: Description
-          private: Private
+  # Discussion View
+  asked_a_question: "%{user_name} asked a question..."
+  replied: "%{user_name} replied..."
+  posted_note: "%{user_name} posted an internal note..."
+  type_reply: Type your reply, or select from a common message below
+  select_common: Select Common Reply
+  reply: Reply
+  internal_note: Internal Note
+  mark_as_resolved: Mark as resolved
+  upvote:
+    one: "Upvote | %{count}"
+    other: "Upvote | %{count}"
 
-      helpers:
-        submit:
-          topic:
-            create: Start New Discussion
-          post:
-            create:
+  # Content
+  new_category: New Category
+  new_content: New Content
+  front_page_categories: Front Page Categories
+  other_categories: Other Categories
+  edit: Edit
+  edit_category: Edit Category
+  select_category: Select Category
+  delete: Delete
+  view_and_edit: "View and Edit Content"
+  delete_confirm: "Please confirm you want to DELETE this!"
+  select_icon_helptext: "Select an icon to associate with this category (optional)"
+  translate: "Translate to a different language"
+  view_on_site: "View on Site"
+  written_on: "Written on %{date_written}"
+  content_last_updated: "Last Updated on %{date_updated}"
+  featured_content: "Featured"
+  draft_content: "Draft"
+  published_content: "Published"
+  additional_settings: "Additional Settings"
+  content_status: "Content Status"
+  convert_content: 'Save as an article or common reply'
+  upload_image: 'Upload Image'
+  new_discussion: 'Create new discussion from this'
+  new_discussion_post: 'Discussion #%{topic_id} was created from this one'
+  new_discussion_topic_title: 'Split from #%{original_id}-%{original_name}'
+  change_owner_note: 'The creator of this topic was changed from %{old} to %{new}'
 
-    breadcrumbs:
-      application:
-        root: *root
-      categories:
-        root: *root
-      docs:
-        root: *root
-      forums:
-        root: *root
-      topics:
-        root: *root
-      posts:
-        root: *root
-      result:
-        root: *root
+  # Internal Content
+  no_internal_content_title: "There's no internal documentation written yet!"
+  no_internal_content_text: "Dont worry ! To contribute with the internal documentation, go to Helpcenter > Content. And add a new Internal type of Category, then share your knowledge with your team writing some Docs!"
+
+  # Communities
+  new_community: Create New Community
+  create_new_community: Create New Community
+  layout_select: Select Format
+  layout_table: Table
+  layout_grid: Grid
+  layout_qna: Q&A
+
+  # Mail messages
+  new_user_subject: "Welcome to %{site_name}"
+  hello: "Hello %{user_name}"
+  new_user: "Thank you for contacting us.  Your message has been received by our support team and we will be in touch with you shortly with a response."
+  account_generated: "An account has been generated for you. To sign in, please use this link:"
+  above_this_line: "Make sure your reply appears above this line"
+  message_id: "Message ID"
+  message_response: "The following message has been posted in response to your question:"
+  view_online: "View this online:"
+
+  # Admin notifications
+  notify_new_private: "A new customer ticket has been received from %{user_name}:"
+  notify_new_public: "A new public customer message has been posted by %{user_name}:"
+  notify_new_reply: "A new customer reply has been received from %{user_name}:"
+  to_reply: 'Reply to this message directly or online:'
+
+  # Notifications settings panel
+  notify_on_private: "Email me when a new ticket has been received"
+  notify_on_public: "Email me when a public customer question has been posted"
+  notify_on_reply: "Email me when a new reply to a ticket has been received"
+
+  # settings
+  agent_settings: "Agent Settings"
+  notifications: "Notifications"
+  settings: "Settings"
+  general: "General"
+  design: "Design"
+  international: "International"
+  widget: "Embeddable Widget"
+  common_replies: "Common Replies"
+  integrations: "Integrations"
+
+  # API Key Managmeent
+  api_keys: "API Keys"
+  key_name: "Key Name"
+  token: "Token"
+  add_key: "Add a New Key"
+  expire_token: "Expire Token"
+  expired: "Expired"
+  expire_confirm: "Please confirm your really want to expire this token."
+  spec_note: "You can read and test out an interactive API spec at: "
+
+  # Insights
+  team_insights: "Team Insights"
+  filter_by_date: "Filter by date"
+  today: "Today"
+  yesterday: "Yesterday"
+  this_week: "This week"
+  last_week: "Last week"
+  this_month: "This month"
+  last_month: "Last month"
+  date_range: "Date Range"
+  insight_start_range: "Start date:"
+  insight_end_range: "End date:"
+  insight_filter: "Filter"
+  insights_blurb_one:
+    one: "<strong>%{period}</strong> your users opened 1 new ticket"
+    other: "<strong>%{period}</strong> your users opened <strong>%{count} new tickets</strong>"
+  insights_blurb_two: "of which your team replied to <strong>%{number_replied} (%{percentage_replied})</strong>"
+  insights_blurb_three: "with a median response time of <strong>%{response_time}</strong>"
+  no_discussions: "No new tickets have been opened <strong>%{period}</strong>"
+  assigned_topics: "Assigned Topics"
+  responded: "Responded"
+  closed: "Closed"
+  replies: "Replies"
+  median_time: "Median time to first response"
+
+
+
+  activerecord:
+    attributes:
+      user:
+        email: Email
+        password: Password
+        name: Name
+        company: Company
+        work_phone: Work
+        home_phone: Phone
+        cell_phone: Cell
+        city: City
+        state: State
+        signature: Signature
+      topic:
+        name: Question
+      post:
+        kind: Genre
+      category:
+        name: Name
+        icon: Icon
+        keywords: Keywords
+        title_tag: Title Tag
+        meta_description: Meta Description
+        front_page: Front Page
+        active: Active
+        visibility: Visibility
+        visibility_label:
+          all: All
+          public: Public
+          internal: Internal
+      doc:
+        title: Title
+        meta_description: Meta Description
+        title_tag: Title Tag
+        keywords: Keywords
+        category_id: Category
+        active: Status
+        front_page: Featured on front page?
+      forum:
+        name: Name
+        description: Description
+        private: Private
+        layout: Layout
+        allow_topic_voting: Allow topic voting?
+        allow_post_voting: Allow post voting?
+
     helpers:
-      actions: "Actions"
-      links:
-        back: "Back"
-        cancel: "Cancel"
-        confirm: "Are you sure?"
-        destroy: "Delete"
-        new: "New"
-        edit: "Edit"
-      titles:
-        edit: "Edit %{model}"
-        save: "Save %{model}"
-        new: "New %{model}"
-        delete: "Delete %{model}"
+      submit:
+        topic:
+          create: Start New Discussion
+        post:
+          create:
+
+  breadcrumbs:
+    application:
+      root: *root
+    categories:
+      root: *root
+    docs:
+      root: *root
+    forums:
+      root: *root
+    locales:
+      root: *root
+    topics:
+      root: *root
+    posts:
+      root: *root
+    result:
+      root: *root
+    admin:
+      internal_categories:
+        root: *root
+      internal_docs:
+        root: *root
+  helpers:
+    actions: "Actions"
+    links:
+      back: "Back"
+      cancel: "Cancel"
+      confirm: "Are you sure?"
+      destroy: "Delete"
+      new: "New"
+      edit: "Edit"
+    titles:
+      edit: "Edit %{model}"
+      save: "Save %{model}"
+      new: "New %{model}"
+      delete: "Delete %{model}"
+
+  number:
+    human:
+      decimal_units:
+        format: "%n%u"
+        units:
+          unit: ""
+          thousand: k
+          million: M
+          billion: B
+          trillion: T
+          quadrillion: Q


### PR DESCRIPTION
The presence of a namespace "flat" at the top of `en.yml` prevented text customizations from working, and caused helpy to continue to use config/locales/en.yml instead.