### PR TITLE
Updated light theme sidebar search button

### DIFF
--- a/app/themes/light/assets/stylesheets/light/light.scss
+++ b/app/themes/light/assets/stylesheets/light/light.scss
@@ -680,6 +680,14 @@ header {
   margin-top: 20px;
 }
 
+.search-btn {
+  width: 100%;
+
+  span {
+    color: #333 !important;
+  }
+}
+
 .nav {
   padding-top: 30px;
 

--- a/app/themes/light/views/layouts/light.html.erb
+++ b/app/themes/light/views/layouts/light.html.erb
@@ -39,7 +39,7 @@
 				    <div class="input-group">
 				      <%= text_field_tag('q', nil, placeholder: t(:search_placeholder, default: "Enter a keyword, topic, or question"), id: 'search-field', class: 'form-control', value: params[:q]) %>
 				      <div class="input-group-btn">
-				        <button type="submit" class="btn btn-default" aria-label="Search">
+				        <button type="submit" class="btn btn-default search-btn" aria-label="Search">
 				          <span class="glyphicon glyphicon-search"></span>
 				        </button>
 				      </div>
@@ -103,7 +103,16 @@
 $('#right-menu').sidr({
   name: 'nav',
   side: 'right',
-	source: '#menu'
+	source: '#menu',
+  onOpen: function(){
+    // Re-name font Icons to correct classnames
+    $("[class*='sidr-class-glyphicon'], [class*='sidr-class-btn']").attr('class',
+      function( i, c ) {
+        c = c.replace(/sidr-class-/g, '');
+        return c;
+      }
+    );
+  }
 });
 
 // Close menu on click


### PR DESCRIPTION
Addressing https://github.com/helpyio/helpy/issues/732

The sidr plugin prefixed sidr-class/sidr-id to its internal contents' selectors. This prevented the  `glyphicon` and `btn` styling from displaying. This commit [removes the sidr prefixes](https://github.com/artberri/sidr/issues/259) for the sidebar search button as well as updates the styling.

I didn't go for the `renaming: false` option because it changed the styling of the entire sidebar too much.

<img width="534" alt="screen shot 2018-01-19 at 7 04 01 am" src="https://user-images.githubusercontent.com/3513997/35154624-1b201e46-fce8-11e7-99ef-e7d071954dd8.png">
