### PR TITLE
Update sidr button styling to display for flat theme

### DIFF
--- a/app/themes/flat/assets/stylesheets/flat/flat.scss
+++ b/app/themes/flat/assets/stylesheets/flat/flat.scss
@@ -680,6 +680,14 @@ header {
   margin-top: 20px;
 }
 
+.search-btn {
+  width: 100%;
+
+  span {
+    color: #333 !important;
+  }
+}
+
 .nav {
   padding-top: 30px;
 

--- a/app/themes/flat/views/layouts/flat.html.erb
+++ b/app/themes/flat/views/layouts/flat.html.erb
@@ -39,7 +39,7 @@
 				    <div class="input-group">
 				      <%= text_field_tag('q', nil, placeholder: t(:search_placeholder, default: "Enter a keyword, topic, or question"), id: 'search-field', class: 'form-control', value: params[:q]) %>
 				      <div class="input-group-btn">
-				        <button type="submit" class="btn btn-default" aria-label="Search">
+				        <button type="submit" class="btn btn-default search-btn" aria-label="Search">
 				          <span class="glyphicon glyphicon-search"></span>
 				        </button>
 				      </div>
@@ -103,7 +103,16 @@
 $('#right-menu').sidr({
   name: 'nav',
   side: 'right',
-	source: '#menu'
+	source: '#menu',
+  onOpen: function(){
+    // Re-name font Icons to correct classnames
+    $("[class*='sidr-class-glyphicon'], [class*='sidr-class-btn']").attr('class',
+      function( i, c ) {
+        c = c.replace(/sidr-class-/g, '');
+        return c;
+      }
+    );
+  }
 });
 
 // Close menu on click


### PR DESCRIPTION
Added the same changes that were in https://github.com/helpyio/helpy/pull/762 for flat theme. As mentioned in the previous PR:

*The sidr plugin prefixed sidr-class/sidr-id to its internal contents' selectors. This prevented the glyphicon and btn styling from displaying. This commit removes the sidr prefixes for the sidebar search button as well as updates the styling.*

<img width="442" alt="screen shot 2018-01-31 at 3 09 28 pm" src="https://user-images.githubusercontent.com/3513997/35652683-962ad33c-0699-11e8-9a90-cb2eb3a2ba24.png">

