### PR TITLE
when logging out, return to the correct locale

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,9 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   around_action :set_time_zone, if: :current_user
 
+  # prevents locale from getting carried over- see https://github.com/plataformatec/devise/issues/3569
+  after_action :reset_locale
+
   def url_options
     { locale: I18n.locale, theme: params[:theme] }.merge(super)
   end
@@ -126,6 +129,10 @@ class ApplicationController < ActionController::Base
     else
       I18n.locale = @browser_locale
     end
+  end
+
+  def reset_locale
+    I18n.locale = AppSettings['i18n.default_locale']
   end
 
   def set_vars

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,6 +1,12 @@
 class RegistrationsController < Devise::RegistrationsController
   theme :theme_chosen
 
+  # prevents locale from getting carried over- see https://github.com/plataformatec/devise/issues/3569
+  prepend_before_action :require_no_authentication, :only => [ :new, :create ]
+  prepend_before_action :allow_params_authentication!, :only => :create
+  prepend_before_action { request.env["devise.skip_timeout"] = true }
+  prepend_before_action :set_locale
+
   # Overwrite update_resource to let users to update their user without giving their password
   def update_resource(resource, params)
     unless current_user.provider.nil?

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,3 +1,11 @@
 class SessionsController < Devise::SessionsController
   theme :theme_chosen
+
+  # prevents locale from getting carried over- see https://github.com/plataformatec/devise/issues/3569
+  prepend_before_action :require_no_authentication, :only => [ :new, :create ]
+  prepend_before_action :allow_params_authentication!, :only => :create
+  prepend_before_action { request.env["devise.skip_timeout"] = true }
+  prepend_before_action :set_locale
+  after_action :reset_locale
+
 end


### PR DESCRIPTION
On multilingual Helpy sites, the helpcenter can display in an incorrect locale.  This attempts to fix that.
#759