### PR TITLE
Remove mailcatcher/ sinatra dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -169,7 +169,6 @@ gem 'roo'
 
 group :development do
   gem "better_errors"
-  gem 'mailcatcher'
 
   # Check Eager Loading / N+1 query problems
   gem 'bullet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,6 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     equalizer (0.0.11)
     erubis (2.7.0)
-    eventmachine (1.0.9.1)
     execjs (2.6.0)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
@@ -315,15 +314,6 @@ GEM
     mail (2.7.0)
       mini_mime (>= 0.1.1)
     mail_extract (0.1.4)
-    mailcatcher (0.6.4)
-      activesupport (~> 4.0)
-      eventmachine (= 1.0.9.1)
-      mail (~> 2.3)
-      rack (~> 1.5)
-      sinatra (~> 1.2)
-      skinny (~> 0.2.3)
-      sqlite3 (~> 1.3)
-      thin (~> 1.5.0)
     maildir (2.2.1)
     mailman (0.7.3)
       activesupport (>= 2.3.4)
@@ -407,8 +397,6 @@ GEM
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-cors (0.4.0)
-    rack-protection (1.5.3)
-      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.10)
@@ -522,13 +510,6 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
-    sinatra (1.4.7)
-      rack (~> 1.5)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
-    skinny (0.2.4)
-      eventmachine (~> 1.0.0)
-      thin (>= 1.5, < 1.7)
     slim (3.0.6)
       temple (~> 0.7.3)
       tilt (>= 1.3.3, < 2.1)
@@ -541,7 +522,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.11)
     staccato (0.4.5)
     sucker_punch (2.0.1)
       concurrent-ruby (~> 1.0.0)
@@ -553,10 +533,6 @@ GEM
       activerecord (>= 3.2)
     themes_on_rails (0.4.0)
       rails (>= 3.2)
-    thin (1.5.1)
-      daemons (>= 1.0.9)
-      eventmachine (>= 0.12.6)
-      rack (>= 1.0.0)
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.2)
@@ -667,7 +643,6 @@ DEPENDENCIES
   kaminari-i18n
   launchy
   mail_extract
-  mailcatcher
   mailman
   mini_magick
   minitest


### PR DESCRIPTION
Mailcatcher is a great development tool, but it does not need to be in the Gemfile.  Solves a current security advisory as well.  You could also just run `bundle update`