### PR TITLE
Fix error in docs/show when no forum in db

### DIFF
--- a/app/controllers/admin/internal_docs_controller.rb
+++ b/app/controllers/admin/internal_docs_controller.rb
@@ -26,7 +26,7 @@ class Admin::InternalDocsController < Admin::BaseController
 
   def define_forum_for_docs
     @forum = Forum.for_docs.first
-    @comment = @forum.topics.new
+    @comment = @forum.topics.new unless @forum.nil?
   end
 
   def define_topic_for_doc

--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -59,7 +59,7 @@ class DocsController < ApplicationController
 
   def define_forum_for_docs
     @forum = Forum.for_docs.first
-    @comment = @forum.topics.new
+    @comment = @forum.topics.new unless @forum.nil?
   end
 
   def define_topic_for_doc

--- a/test/controllers/admin/internal_docs_controller_test.rb
+++ b/test/controllers/admin/internal_docs_controller_test.rb
@@ -18,4 +18,11 @@ class Admin::InternalDocsControllerTest < ActionController::TestCase
     assert_nil assigns(:doc)
     assert_response :redirect
   end
+
+  test "showing doc when there isn't any forum" do
+    Forum.destroy_all
+    get :show, internal_category_id: 1, id: 1
+    assert_equal "Article 1", assigns(:page_title)
+    assert_response :success
+  end
 end

--- a/test/controllers/docs_controller_test.rb
+++ b/test/controllers/docs_controller_test.rb
@@ -65,4 +65,9 @@ class DocsControllerTest < ActionController::TestCase
     end
   end
 
+  test "a browsing user should be able to show a document when there isn't any forum" do
+    Forum.destroy_all
+    get :show, id: 1, locale: "en"
+    assert_response :success
+  end
 end


### PR DESCRIPTION
An error is thrown after a fresh install if we try to open a doc because of a `nil` value.
This PR fixes the issue.