### PR TITLE
Fix 2 French translations and 1 typo in views

### DIFF
--- a/app/themes/singular/views/docs/show.html.erb
+++ b/app/themes/singular/views/docs/show.html.erb
@@ -47,7 +47,7 @@
         <div class="less-important"><%= last_active_time(@doc.updated_at) %></div>
       </div>
       <div id="doc-tags" class="doc-meta col-md-4 col-sm-4 col-xs-12 text-center">
-        <div class="more-important meta-header"><%= I18n.t("Tagged", default: "Tagged") %>:</div>
+        <div class="more-important meta-header"><%= I18n.t("tagged", default: "Tagged") %>:</div>
         <div class="more-important meta-header"><% tag_listing(@doc.tag_list, "doc") %></div>
       </div>
     </div>

--- a/app/views/admin/internal_docs/show.html.erb
+++ b/app/views/admin/internal_docs/show.html.erb
@@ -26,7 +26,7 @@
           <div class="less-important"><%= last_active_time(@doc.updated_at) %></div>
         </div>
         <div id="doc-tags" class="doc-meta col-md-4">
-          <div class="more-important meta-header"><%= I18n.t("Tagged", default: "Tagged") %>:</div>
+          <div class="more-important meta-header"><%= I18n.t("tagged", default: "Tagged") %>:</div>
           <div class="more-important meta-header"><% tag_listing(@doc.tag_list, "doc") %></div>
         </div>
       </div>

--- a/app/views/docs/show.html.erb
+++ b/app/views/docs/show.html.erb
@@ -42,7 +42,7 @@
       <div class="less-important"><%= last_active_time(@doc.updated_at) %></div>
     </div>
     <div id="doc-tags" class="doc-meta">
-      <div class="more-important meta-header"><%= I18n.t("Tagged", default: "Tagged") %>:</div>
+      <div class="more-important meta-header"><%= I18n.t("tagged", default: "Tagged") %>:</div>
       <div class="more-important meta-header"><% tag_listing(@doc.tag_list, "doc") %></div>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,6 +61,7 @@ en:
   # Knowledgebase
   written_by: "Written By"
   last_edited: "Last Edited"
+  tagged: "Tagged"
   asked_before: "Has your question been answered before? We think these may be similar"
 
   # Tickets

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -16,7 +16,7 @@ fr:
   login: "Connexion"
   logout: "Déconnexion"
   register: "S'inscrire"
-  back_to: "Retour à"
+  back_to: "Retourner sur"
   welcome_back: "Bienvenue à nouveau %{username}"
   your_profile: "Votre profil"
   your_tickets: "Vos tickets"
@@ -59,7 +59,7 @@ fr:
       other: "%{count} messages cachés"
 
   # Knowledgebase
-  written_by: "écrit par"
+  written_by: "Écrit par"
   last_edited: "Dernière mise à jour"
   asked_before: "Est-ce que votre question a déjà été posée ? Nous pensons que celles-ci peuvent être similaires"
 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -61,6 +61,7 @@ fr:
   # Knowledgebase
   written_by: "Écrit par"
   last_edited: "Dernière mise à jour"
+  tagged: "Tags"
   asked_before: "Est-ce que votre question a déjà été posée ? Nous pensons que celles-ci peuvent être similaires"
 
   # Tickets

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -61,6 +61,7 @@ nl:
   # Knowledgebase
   written_by: "Geschreven door"
   last_edited: "Laatst bewerkt"
+  tagged: "Tags"
   asked_before: "Is uw vraag al eerder beantwoord? We denken dat deze kunnen gelijkaardig zijn"
 
   # Tickets


### PR DESCRIPTION
Fix 2 French translations and add a missing one.
I also fixed a typo (`Tagged` was used instead of `Tagged`)