### PR TITLE
fix clientside validations for admin groups controller

### DIFF
--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -39,11 +39,13 @@ class Admin::GroupsController < Admin::BaseController
   end
 
   def create
-    tag = ActsAsTaggableOn::Tag.create(group_params)
-    if ActsAsTaggableOn::Tagging.create(tag_id: tag.id, context: "teams")
-      redirect_to admin_groups_path
-    else
-      render new_admin_group_path
+    @team = ActsAsTaggableOn::Tag.create(group_params)
+    if ActsAsTaggableOn::Tagging.create(tag_id: @team.id, context: "teams")
+      if @team.save
+        redirect_to admin_groups_path
+      else
+        render :new
+      end
     end
   end
 


### PR DESCRIPTION
Issue #824 

Fix to stop the groups `new` & `edit` submission failing silently.

Let me know if there's any changes you'd like me to make, I'm not totally familiar with the `ActsAsTaggableOn` methods, so I hope didn't miss anything obvious.

Cheers,

Rich

