### PR TITLE
Add a link to edit page of docs

### DIFF
--- a/app/views/docs/show.html.erb
+++ b/app/views/docs/show.html.erb
@@ -27,7 +27,13 @@
   background-color: transparent;
 }
 </style>
-
+<% if current_user && current_user.is_editor? %>
+<div class="row edit-row">
+  <div id="doc-edit" class="text-right">
+    <div class="more-important meta-header"><%= link_to I18n.t("edit", default: "Edit"), edit_admin_category_doc_path(@doc.category.id, @doc.id, lang: I18n.locale) %></div>
+  </div>
+</div>
+<% end %>
 <div class="row content-row">
   <div class="col-md-3 hidden-xs hidden-sm">
     <div id="written-by" class="doc-meta">


### PR DESCRIPTION
### What
If the user is editor or up, a link will appear on doc pages. The link will lead to the edit page of the corresponding doc.

### Why
This provides a better workflow for editors to correct spelling mistakes etc.

Please provide feedback and/or ask questions about this. I am more than happy to correct the code and answer questions if needed.

### EDIT
Here's the screenshot @ottok proposed:
![2018-08-22-095155_1179x408_scrot](https://user-images.githubusercontent.com/16290563/44447687-9af13300-a5f1-11e8-8998-5035b4d735df.png)