### PR TITLE
WIP html header and footer 

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -38,15 +38,15 @@ class Admin::BaseController < ApplicationController
   # agent is next and admin has access to everything:
 
   def verify_editor
-    (current_user.nil?) ? redirect_to(root_path) : (redirect_to(root_path) unless current_user.is_editor?)
+    (current_user.nil?) ? redirect_to(root_path) : (redirect_to(admin_root_path) unless current_user.is_editor?)
   end
 
   def verify_agent
-    (current_user.nil?) ? redirect_to(root_path) : (redirect_to(root_path) unless current_user.is_agent?)
+    (current_user.nil?) ? redirect_to(root_path) : (redirect_to(admin_root_path) unless current_user.is_agent?)
   end
 
   def verify_admin
-    (current_user.nil?) ? redirect_to(root_path) : (redirect_to(root_path) unless current_user.is_admin?)
+    (current_user.nil?) ? redirect_to(root_path) : (redirect_to(admin_root_path) unless current_user.is_admin?)
   end
 
   def remote_search

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -1,7 +1,7 @@
 class Admin::SettingsController < Admin::BaseController
 
-  before_action :verify_admin, except: ['index', 'profile']
-  before_action :verify_agent, only: ['index']
+  before_action :verify_admin, except: ['profile']
+  #before_action :verify_agent, only: ['index']
   skip_before_action :verify_authenticity_token
 
   def index
@@ -137,7 +137,6 @@ class Admin::SettingsController < Admin::BaseController
                         default: "The changes you have been saved.  Some changes are only visible on your helpcenter site: #{AppSettings['settings.site_url']}")
 
     TestMailer.new_test(current_user.email).deliver_later if params[:send_test] == "1"
-
     redirect_to admin_email_settings_path
   end
 

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -52,6 +52,103 @@ class Admin::SettingsController < Admin::BaseController
             type: 'image/png', disposition: 'inline', stream: false
   end
 
+  def update_general
+    update_params = params.keys.select { |key| key.to_s.match('settings.') }
+    update_params += params.keys.select { |key| key.to_s.match('branding.') }
+    settings_update(update_params)
+
+    # prevent null value for colors
+    AppSettings["branding.ticketing_color"] = "#245566" if params["branding.ticketing_color"].blank?
+    AppSettings["branding.ticketing_bg_color"] = "#f6f7e8" if params["branding.ticketing_bg_color"].blank?
+
+    flash[:success] = t(:settings_changes_saved,
+                        site_url: AppSettings['settings.site_url'],
+                        default: "The changes you have been saved.  Some changes are only visible on your helpcenter site: #{AppSettings['settings.site_url']}")
+    redirect_to admin_general_settings_path
+  end
+
+  def update_design
+    update_params = params.keys.select { |key| key.to_s.match('design.') }
+    update_params += params.keys.select { |key| key.to_s.match('css.') }
+    update_params -= ['uploader.design.header_logo','uploader.design.favicon']
+
+    settings_update(update_params)
+    @logo = Logo.new
+    @logo.file = params['uploader.design.header_logo']
+    @logo.save
+
+    @thumb = Logo.new
+    @thumb.file = params['uploader.design.favicon']
+    @thumb.save
+
+    flash[:success] = t(:settings_changes_saved,
+                        site_url: AppSettings['settings.site_url'],
+                        default: "The changes you have been saved.  Some changes are only visible on your helpcenter site: #{AppSettings['settings.site_url']}")
+    redirect_to admin_design_settings_path
+  end
+
+  def update_theme
+    update_params = params.keys.select { |key| key.to_s.match('theme.') }
+    settings_update(update_params)
+
+    flash[:success] = t(:settings_changes_saved,
+                        site_url: AppSettings['settings.site_url'],
+                        default: "The changes you have been saved.  Some changes are only visible on your helpcenter site: #{AppSettings['settings.site_url']}")
+    redirect_to admin_theme_settings_path
+  end
+
+  def update_integration
+    update_params = params.keys.select { |key| key.to_s.match('settings.') }
+    update_params += params.keys.select { |key| key.to_s.match('cloudinary.') }
+    settings_update(update_params)
+
+    flash[:success] = t(:settings_changes_saved,
+                        site_url: AppSettings['settings.site_url'],
+                        default: "The changes you have been saved.  Some changes are only visible on your helpcenter site: #{AppSettings['settings.site_url']}")
+    redirect_to admin_integration_settings_path
+  end
+
+  def update_widget
+    update_params = params.keys.select { |key| key.to_s.match('widget.') }
+    settings_update(update_params)
+
+    flash[:success] = t(:settings_changes_saved,
+                        site_url: AppSettings['settings.site_url'],
+                        default: "The changes you have been saved.  Some changes are only visible on your helpcenter site: #{AppSettings['settings.site_url']}")
+    redirect_to admin_widget_settings_path
+  end
+
+  def update_i18n
+    update_params = params.keys.select { |key| key.to_s.match('i18n.') }
+    settings_update(update_params)
+
+    flash[:success] = t(:settings_changes_saved,
+                        site_url: AppSettings['settings.site_url'],
+                        default: "The changes you have been saved.  Some changes are only visible on your helpcenter site: #{AppSettings['settings.site_url']}")
+    redirect_to admin_i18n_settings_path
+  end
+
+  def update_email
+    update_params = params.keys.select { |key| key.to_s.match('email.') }
+    settings_update(update_params)
+
+    flash[:success] = t(:settings_changes_saved,
+                        site_url: AppSettings['settings.site_url'],
+                        default: "The changes you have been saved.  Some changes are only visible on your helpcenter site: #{AppSettings['settings.site_url']}")
+
+    TestMailer.new_test(current_user.email).deliver_later if params[:send_test] == "1"
+
+    redirect_to admin_email_settings_path
+  end
+
+  def settings_update(update_params)
+    update_params.each do |setting|
+      AppSettings[setting] = params[setting]
+    end
+  end
+
+  # NOTE Update settings is deprecated and is left here only if plugins or extensions
+  # rely on it
   def update_settings
     # NOTE: We iterate through settings here to establish our universe of settings to save
     # this means if you add a setting, you MUST declare a default value in the "default_settings intializer"

--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -9,7 +9,8 @@ module EmailHelper
     text.gsub('%ticket_link%', "#{t('view_online', default: 'View this online:')} #{ticket_url(@topic, host: AppSettings['settings.site_url'])}")
   end
 
-  def body_tokens(text, user)
-    text.gsub('%customer_name%', user.name)
+  def body_tokens(text, topic)
+    text.gsub('%customer_name%', topic.user.name)
+    text.gsub('%customer_email_address', topic.user.email)
   end
 end

--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -3,4 +3,13 @@ module EmailHelper
     attachments[image] = File.read(Rails.root.join("app/assets/images/#{image}"))
     image_tag attachments[image].url, **options
   end
+
+  # replace tokens with active content
+  def footer_tokens(text)
+    text.gsub('%ticket_link%', "#{t('view_online', default: 'View this online:')} #{ticket_url(@topic, host: AppSettings['settings.site_url'])}")
+  end
+
+  def body_tokens(text, user)
+    text.gsub('%customer_name%', user.name)
+  end
 end

--- a/app/mailers/post_mailer.rb
+++ b/app/mailers/post_mailer.rb
@@ -34,5 +34,4 @@ class PostMailer < ActionMailer::Base
       subject: "[#{AppSettings['settings.site_name']}] ##{@topic.id}-#{@topic.name}"
       )
   end
-
 end

--- a/app/mailers/post_mailer.rb
+++ b/app/mailers/post_mailer.rb
@@ -4,11 +4,14 @@ class PostMailer < ActionMailer::Base
 
   add_template_helper(ApplicationHelper)
   add_template_helper(PostsHelper)
+  add_template_helper(EmailHelper)
 
   def new_post(post_id)
     @post = Post.find(post_id)
     @topic = @post.topic
     @posts = @topic.posts.where.not(id: @post.id).ispublic.active.reverse
+    @header = Doc.where(title: 'Customer_header').first.present? ? Doc.where(title: 'Customer_header').first.body : ""
+    @footer = Doc.where(title: 'Customer_footer').first.present? ? Doc.where(title: 'Customer_footer').first.body : ""
 
     # Do not send if internal
     return if @topic.kind == 'internal'

--- a/app/mailers/test_mailer.rb
+++ b/app/mailers/test_mailer.rb
@@ -1,0 +1,11 @@
+class TestMailer < ApplicationMailer
+  layout 'mailer'
+
+  def new_test(recipient)
+    mail(
+      to: recipient,
+      from: "#{AppSettings['settings.site_name']} <#{AppSettings['email.admin_email']}>",
+      subject: "[#{AppSettings['settings.site_name']}] Email Test"
+      )
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -144,11 +144,11 @@ class Post < ActiveRecord::Base
   end
 
   def html_formatted_body
-    "#{ActionController::Base.helpers.sanitize(body.gsub(/(?:\n\r?|\r\n?)/, '<br>'), tags: ALLOWED_TAGS, attributes: ALLOWED_ATTRIBUTES)}".html_safe
+    "#{ActionController::Base.helpers.sanitize(ApplicationController.helpers.body_tokens(body, topic.user).gsub(/(?:\n\r?|\r\n?)/, '<br>'), tags: ALLOWED_TAGS, attributes: ALLOWED_ATTRIBUTES)}".html_safe
   end
 
   def text_formatted_body
-    "#{ActionView::Base.full_sanitizer.sanitize(body)}".html_safe
+    "#{ActionView::Base.full_sanitizer.sanitize(ApplicationController.helpers.body_tokens(body, topic.user))}".html_safe
   end
 
   private

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -144,11 +144,11 @@ class Post < ActiveRecord::Base
   end
 
   def html_formatted_body
-    "#{ActionController::Base.helpers.sanitize(ApplicationController.helpers.body_tokens(body, topic.user).gsub(/(?:\n\r?|\r\n?)/, '<br>'), tags: ALLOWED_TAGS, attributes: ALLOWED_ATTRIBUTES)}".html_safe
+    "#{ActionController::Base.helpers.sanitize(ApplicationController.helpers.body_tokens(body, topic).gsub(/(?:\n\r?|\r\n?)/, '<br>'), tags: ALLOWED_TAGS, attributes: ALLOWED_ATTRIBUTES)}".html_safe
   end
 
   def text_formatted_body
-    "#{ActionView::Base.full_sanitizer.sanitize(ApplicationController.helpers.body_tokens(body, topic.user))}".html_safe
+    "#{ActionView::Base.full_sanitizer.sanitize(ApplicationController.helpers.body_tokens(body, topic))}".html_safe
   end
 
   private

--- a/app/views/admin/categories/_doc.html.erb
+++ b/app/views/admin/categories/_doc.html.erb
@@ -23,10 +23,10 @@
     <span id="row-<%= doc.id %>" data-toggle="dropdown" aria-expanded="false" class='btn dropdown-toggle fas fa-ellipsis-v'></span>
     <ul class="dropdown-menu dropdown-menu-right" role="menu">
       <li><%= link_to t(:edit, default: 'Edit'), edit_admin_category_doc_path(doc.category.id, doc.id, lang: I18n.locale) %></li>
-      <li><%= link_to t(:delete, default: 'Delete'), admin_doc_path(doc.id), data: {confirm: t(:delete_confirm, default: 'Please confirm you really want to DELETE this')}, method: :delete, remote: true, class: 'less-important' %></li>
+      <li><%= link_to t(:delete, default: 'Delete'), admin_doc_path(doc.id), data: {confirm: t(:delete_confirm, default: 'Please confirm you really want to DELETE this')}, method: :delete, remote: true, class: 'less-important' if doc.category_id != 2 %></li>
       <li>
         <%= link_to t(:view_on_site, default: 'View on Site'), category_doc_path(doc.category, doc), {target: "_blank"} if doc.category.publicly_viewable? %>
-        <%= link_to t(:view_on_internal_knowledge_base, default: 'View on Internal KB'), admin_internal_category_internal_doc_path(doc.category.id, doc.id), {target: "_blank"} if doc.category.internally_viewable? %>
+        <%= link_to t(:view_on_internal_knowledge_base, default: 'View on Internal KB'), admin_internal_category_internal_doc_path(doc.category.id, doc.id), {target: "_blank"} if doc.category.internally_viewable? && ![1,2].include?(doc.category_id) %>
       </li>
     </ul>
   </div>

--- a/app/views/admin/docs/_form.html.erb
+++ b/app/views/admin/docs/_form.html.erb
@@ -66,7 +66,7 @@
   <% end %>
   <hr/>
   <h4 class="form-subhead"><%= t('additional_settings', default: 'Additional Settings') %>:</h4>
-  <% if @doc.category_id != 1 %>
+  <% if ![1,2].include?(@doc.category_id)  %>
     <div class= "form_group no-translate">
       <label class="control-label" for="tag_list"><%= t('tags', default: 'Tags') %>: </label>
       <%= f.text_field :tag_list, value: @doc.tag_list.to_s, class: 'selectize form-control' %>

--- a/app/views/admin/settings/design.html.erb
+++ b/app/views/admin/settings/design.html.erb
@@ -2,7 +2,7 @@
 
   <%= settings_header('design') %>
 
-  <%= bootstrap_form_tag url: admin_update_settings_path(return_to: 'design'), method: 'put', multipart: true, authenticity_token: true do |f| %>
+  <%= bootstrap_form_tag url: admin_update_design_settings_path, method: 'put', multipart: true, authenticity_token: true do |f| %>
     <div class="settings-section design">
         <div class="row">
           <div class="col-md-1 col-sm-2 col-xs-2">
@@ -13,14 +13,6 @@
             <%= f.text_field 'design.header_logo', class: "hidden-header-logo", value: AppSettings['design.header_logo'], hide_label: true %>
           </div>
         </div>
-        <!-- <div class="row">
-          <div class="col-md-1 col-sm-2 col-xs-2">
-            <%= image_tag(AppSettings['design.footer_mini_logo'], width: 20, class: 'pull-left') %>
-          </div>
-          <div class="col-md-11 col-sm-10 col-xs-10">
-            <%= f.file_field 'design.footer_mini_logo', value: AppSettings['design.footer_mini_logo'], label: t('footer_logo', default: "Footer Logo") %>
-          </div>
-        </div> -->
         <div class="row">
           <div class="col-md-1 col-sm-2 col-xs-2">
             <%= image_tag(AppSettings['design.favicon'], width: 32, class: 'pull-left') %>

--- a/app/views/admin/settings/email.html.erb
+++ b/app/views/admin/settings/email.html.erb
@@ -13,8 +13,8 @@
         <%= f.radio_button 'email.send_email', true, label: t('boolean_yes', default: "Yes"), checked: "#{AppSettings['email.send_email']}" == 'true', class: 'send-email' %>
       <% end %>
       <div class="smtp-settings <%= "hidden" if "#{AppSettings['email.send_email']}" == 'false' %>">
-        <%= f.text_field 'email.admin_email', value: AppSettings['email.admin_email'], label: t('admin_email', default: "Admin Email") %>
-        <%= f.text_field 'email.from_email', value: AppSettings['email.from_email'], label: t('from_email', default: "From Email") %>
+        <%= f.text_field 'email.admin_email', value: AppSettings['email.admin_email'], label: t('admin_email', default: "Admin Email"), validate: { presence: true } %>
+        <%= f.text_field 'email.from_email', value: AppSettings['email.from_email'], label: t('from_email', default: "From Email"), type: 'email' %>
         <%= f.text_field 'email.smtp_mail_username', value: AppSettings['email.smtp_mail_username'], label: t('smtp_mail_username', default: "SMTP Username") %>
         <%= f.password_field 'email.smtp_mail_password', value: AppSettings['email.smtp_mail_password'], label: t('smtp_mail_password', default: "SMTP Password") %>
         <%= f.text_field 'email.mail_smtp', value: AppSettings['email.mail_smtp'], label: t('mail_smtp', default: "SMTP Server") %>

--- a/app/views/admin/settings/email.html.erb
+++ b/app/views/admin/settings/email.html.erb
@@ -2,7 +2,7 @@
 
   <%= settings_header('email') %>
 
-  <%= bootstrap_form_tag url: admin_update_settings_path(return_to: 'email'), method: 'put', multipart: true, authenticity_token: true do |f| %>
+  <%= bootstrap_form_tag url: admin_update_email_settings_path, method: 'put', multipart: true, authenticity_token: true do |f| %>
     <div class="settings-section email" data-hook="admin_settings_email">
       <%= f.select 'email.mail_service',
         options_for_select([['Mailgun', 'mailgun'],['Sendgrid', 'sendgrid'],['Mandrill','mandrill'],['Postmark','postmark'],['Sparkpost','sparkpost']], AppSettings['email.mail_service']),
@@ -20,6 +20,8 @@
         <%= f.text_field 'email.mail_smtp', value: AppSettings['email.mail_smtp'], label: t('mail_smtp', default: "SMTP Server") %>
         <%= f.text_field 'email.mail_port', value: AppSettings['email.mail_port'], label: t('mail_port', default: "SMTP Port") %>
         <%= f.text_field 'email.mail_domain', value: AppSettings['email.mail_domain'], label: t('mail_domain', default: "SMTP Domain") %>
+        <%= f.check_box 'send_test', { checked: true, label: t('send_test_email', default: "Send a test email to administrators"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
+
       </div>
     </div>
     <div class="submit-section">

--- a/app/views/admin/settings/general.html.erb
+++ b/app/views/admin/settings/general.html.erb
@@ -2,7 +2,7 @@
 
   <%= settings_header('general') %>
 
-  <%= bootstrap_form_tag url: admin_update_settings_path(return_to: 'general'), method: 'put', multipart: true, authenticity_token: true do |f| %>
+  <%= bootstrap_form_tag url: admin_update_general_settings_path, method: 'put', multipart: true, authenticity_token: true do |f| %>
     <div class="settings-section">
 
       <h4>Admin Branding</h4>

--- a/app/views/admin/settings/i18n.html.erb
+++ b/app/views/admin/settings/i18n.html.erb
@@ -2,7 +2,7 @@
 
   <%= settings_header('international') %>
 
-  <%= bootstrap_form_tag url: admin_update_settings_path(return_to: 'i18n'), method: 'put', multipart: true, authenticity_token: true do |f| %>
+  <%= bootstrap_form_tag url: admin_update_i18n_settings_path, method: 'put', multipart: true, authenticity_token: true do |f| %>
     <div class="settings-section international" data-hook="admin_settings_international">
       <%= t('supported_locales', default: 'Supported Locales:') %>
       <% I18n.available_locales.sort.each do |locale| %>

--- a/app/views/admin/settings/integration.html.erb
+++ b/app/views/admin/settings/integration.html.erb
@@ -2,7 +2,7 @@
 
   <%= settings_header('integration') %>
 
-  <%= bootstrap_form_tag url: admin_update_settings_path(return_to: 'integration'), method: 'put', multipart: true, authenticity_token: true do |f| %>
+  <%= bootstrap_form_tag url: admin_update_integration_settings_path(return_to: 'integration'), method: 'put', multipart: true, authenticity_token: true do |f| %>
     <div class="settings-section integrations" data-hook="admin_settings_integrations">
       <div class="row integration-item vcenter">
         <div class="col-md-6">

--- a/app/views/admin/settings/theme.html.erb
+++ b/app/views/admin/settings/theme.html.erb
@@ -2,7 +2,7 @@
 
   <%= settings_header('theme') %>
 
-  <%= bootstrap_form_tag url: admin_update_settings_path(return_to: 'theme'), method: 'put', multipart: true, authenticity_token: true do |f| %>
+  <%= bootstrap_form_tag url: admin_update_theme_settings_path(return_to: 'theme'), method: 'put', multipart: true, authenticity_token: true do |f| %>
     <div class="settings-section theme">
       <div class="row">
         <% @themes.each do |theme| %>

--- a/app/views/admin/settings/widget.html.erb
+++ b/app/views/admin/settings/widget.html.erb
@@ -2,7 +2,7 @@
 
   <%= settings_header('widget') %>
 
-  <%= bootstrap_form_tag url: admin_update_settings_path(return_to: 'widget'), method: 'put', multipart: true, authenticity_token: true do |f| %>
+  <%= bootstrap_form_tag url: admin_update_widget_settings_path, method: 'put', multipart: true, authenticity_token: true do |f| %>
     <div class="settings-section widget" data-hook="admin_settings_widget">
       <%= f.check_box 'widget.show_on_support_site', { checked: AppSettings['widget.show_on_support_site'] == "1", label: t('show_widget', default: "Show Widget on Support Site"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
       <%= f.text_field 'widget.background_color', value: AppSettings['widget.background_color'], label: t('widget_background', default: "Widget Background"), class: 'pick-a-color' %>

--- a/app/views/post_mailer/new_post.html.erb
+++ b/app/views/post_mailer/new_post.html.erb
@@ -10,6 +10,7 @@
     list-style: none;
   }
   </style>
+  <%= @header.html_safe %>
   <p style="color: #666;">
     <small>
     <%= t('above_this_line', default: "Make sure your reply appears above this line") %><br/>
@@ -21,16 +22,8 @@
     <%= simple_format(@post.user.signature) if @post.user.signature.present? %>
   </p>
   <%= render :partial => 'posts/thumbnail', locals: { :model_name => @post } %>
-
-
   <%= render partial: 'mailer_shared/post', collection: @posts %>
   <br/>
-  <p style="color: #666;">
-    <small>
-    <strong>Powered by Helpy</strong><br/>
-    Get a Free Helpy Support System for your Site at http://helpy.io/<br/>
-    <%= t('view_online', default: 'View this online:') %> <%= ticket_url(@topic, host: AppSettings['settings.site_url']) %>
-    </small>
-  </p>
+  <%= footer_tokens(@footer).html_safe %>
   </body>
 </html>

--- a/app/views/post_mailer/new_post.text.erb
+++ b/app/views/post_mailer/new_post.text.erb
@@ -1,3 +1,5 @@
+<%= strip_tags(@header) %>
+
 <%= t('above_this_line', default: "Make sure your reply appears above this line") %>
 =================================================================
 <%= t('message_id', default: 'Message ID') %>:<%= @topic.id %>
@@ -9,5 +11,4 @@
 
 <%= t('view_online', default: 'View this online:') %> <%= ticket_url(@topic, host: AppSettings['settings.site_url']) %>
 -----------
-Powered by Helpy
-Get a Free Helpy Support System for your Site at http://helpy.io/
+<%= strip_tags(footer_tokens(@footer)) %>

--- a/app/views/test_mailer/new_test.html.inky
+++ b/app/views/test_mailer/new_test.html.inky
@@ -1,0 +1,9 @@
+<container>
+  <row>
+    <columns class="callout panel">
+      <spacer size="16"></spacer>
+        Your email configuration appears to work :)
+      </p><br/>
+    </columns>
+  </row>
+</container>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,7 +116,7 @@ Rails.application.routes.draw do
     put 'settings/i18n' => 'settings#update_i18n', as: :update_i18n_settings
     put 'settings/email' => 'settings#update_email', as: :update_email_settings
     put 'settings/integration' => 'settings#update_integration', as: :update_integration_settings
-    get 'settings/profile' => 'settings#update_profile', as: :profile_settings
+    get 'settings/profile' => 'settings#profile', as: :profile_settings
 
     # Misc Routes
     post 'shared/update_order' => 'shared#update_order', as: :update_order

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,7 +109,14 @@ Rails.application.routes.draw do
     get 'settings/i18n' => 'settings#i18n', as: :i18n_settings
     get 'settings/email' => 'settings#email', as: :email_settings
     get 'settings/integration' => 'settings#integration', as: :integration_settings
-    get 'settings/profile' => 'settings#profile', as: :profile_settings
+    put 'settings/general' => 'settings#update_general', as: :update_general_settings
+    put 'settings/design' => 'settings#update_design', as: :update_design_settings
+    put 'settings/theme' => 'settings#update_theme', as: :update_theme_settings
+    put 'settings/widget' => 'settings#update_widget', as: :update_widget_settings
+    put 'settings/i18n' => 'settings#update_i18n', as: :update_i18n_settings
+    put 'settings/email' => 'settings#update_email', as: :update_email_settings
+    put 'settings/integration' => 'settings#update_integration', as: :update_integration_settings
+    get 'settings/profile' => 'settings#update_profile', as: :profile_settings
 
     # Misc Routes
     post 'shared/update_order' => 'shared#update_order', as: :update_order

--- a/lib/tasks/update.rake
+++ b/lib/tasks/update.rake
@@ -1,0 +1,16 @@
+namespace :update do
+  desc "Create placeholder data for DB"
+  task :enable_templates => :environment do
+    cat = Category.find(2)
+    cat.update_attribute(:meta_description, 'Customize the header and footer of customer email messages')
+    cat.docs.create(title: 'Customer_header', body:'<!-- -->') #unless Doc.where(title: 'customer_header').count > 0
+    cat.docs.create(title: 'Customer_footer', body:'<p style="color: #666;">
+  <small>
+    <strong>Powered by Helpy</strong><br>
+  	Get a Free Helpy Support System for your Site at
+  	<a href="https://helpy.io/">https://helpy.io/</a>
+  </small>
+</p>
+<p style="color: #666;"><small>%ticket_link%</small></p>') #unless Doc.where(title: 'customer_footer').count > 0
+  end
+end

--- a/test/controllers/admin/api_keys_controller_test.rb
+++ b/test/controllers/admin/api_keys_controller_test.rb
@@ -22,13 +22,13 @@ class Admin::ApiKeysControllerTest < ActionController::TestCase
   test "a signed out user should not be able to load the api page" do
     sign_in users(:user)
     get :index, locale: :en
-    assert_redirected_to root_path
+    assert_redirected_to admin_root_path
   end
 
   test "a signed in user should not be able to load the api page" do
     sign_in users(:user)
     get :index, locale: :en
-    assert_redirected_to root_path
+    assert_redirected_to admin_root_path
   end
 
   test "an admin should be able to load the api key page" do

--- a/test/controllers/admin/categories_controller_test.rb
+++ b/test/controllers/admin/categories_controller_test.rb
@@ -57,31 +57,31 @@ class Admin::CategoriesControllerTest < ActionController::TestCase
   test "a signed in user should be able to load get new" do
     sign_in users(:user)
     get :new, locale: :en
-    assert_redirected_to root_path
+    assert_redirected_to admin_root_path
   end
 
   test "a signed in user should not be able to load edit" do
     sign_in users(:user)
     get :edit, { id: 1, locale: :en }
-    assert_redirected_to root_path
+    assert_redirected_to admin_root_path
   end
 
   test "a signed in user should not be able to load create" do
     sign_in users(:user)
     post :create, category: {name: "some name"}, locale: :en
-    assert_redirected_to root_path
+    assert_redirected_to admin_root_path
   end
 
   test "a signed in user should not be able to load update" do
     sign_in users(:user)
     patch :update, { id: 1, category: { name: "some name" }, locale: :en }
-    assert_redirected_to root_path
+    assert_redirected_to admin_root_path
   end
 
   test "a signed in user should not be able to load destroy" do
     sign_in users(:user)
     delete :destroy, { id: 1, locale: :en}
-    assert_redirected_to root_path
+    assert_redirected_to admin_root_path
   end
 
   # admin logged in, should get these pages

--- a/test/controllers/admin/docs_controller_test.rb
+++ b/test/controllers/admin/docs_controller_test.rb
@@ -63,13 +63,13 @@ class Admin::DocsControllerTest < ActionController::TestCase
   test "a signed in user should not be able to load new" do
     sign_in users(:user)
     get :new, locale: :en
-    assert_redirected_to root_path
+    assert_redirected_to admin_root_path
   end
 
   test "a signed in user should not be able to load edit" do
     sign_in users(:user)
     get :edit, { id: 3, locale: :en}
-    assert_redirected_to root_path
+    assert_redirected_to admin_root_path
   end
 
   test "a signed in user should not be able to load create" do
@@ -77,13 +77,13 @@ class Admin::DocsControllerTest < ActionController::TestCase
     assert_difference "Doc.count", 0 do
       post :create, doc: {title: "some name", body: "some body text", category_id: 1}, locale: :en
     end
-    assert_redirected_to root_path
+    assert_redirected_to admin_root_path
   end
 
   test "a signed in user should not be able to load update" do
     sign_in users(:user)
     patch :update, { id: 1, doc: {title: "some name", body: "some body text", category_id: 1}, locale: :en }
-    assert_redirected_to root_path
+    assert_redirected_to admin_root_path
   end
 
   test "a signed in user should not be able to load destroy" do
@@ -91,7 +91,7 @@ class Admin::DocsControllerTest < ActionController::TestCase
     assert_difference "Doc.count", 0 do
       delete :destroy, { id: 3, locale: :en }
     end
-    assert_redirected_to root_path
+    assert_redirected_to admin_root_path
   end
 
   # Admin actions

--- a/test/controllers/admin/forums_controller_test.rb
+++ b/test/controllers/admin/forums_controller_test.rb
@@ -56,31 +56,31 @@ class Admin::ForumsControllerTest < ActionController::TestCase
     test "a #{unauthorized} should not get new" do
       sign_in users(unauthorized.to_sym)
       get :new, locale: :en
-      assert_redirected_to root_path
+      assert_redirected_to admin_root_path
     end
 
     test "a #{unauthorized} should not get edit" do
       sign_in users(unauthorized.to_sym)
       get :edit, { id: 3, locale: :en }
-      assert_redirected_to root_path
+      assert_redirected_to admin_root_path
     end
 
     test "a #{unauthorized} should not get create" do
       sign_in users(unauthorized.to_sym)
       post :create, forum: {name: "some name", description: "some descrpition"}, locale: :en
-      assert_redirected_to root_path
+      assert_redirected_to admin_root_path
     end
 
     test "a #{unauthorized} should not get update" do
       sign_in users(unauthorized.to_sym)
       patch :update, { id: 3, forum: {name: "some name", description: "some descrpition"}, locale: :en }
-      assert_redirected_to root_path
+      assert_redirected_to admin_root_path
     end
 
     test "a #{unauthorized} should not get destroy" do
       sign_in users(unauthorized.to_sym)
       delete :destroy, { id: 3, locale: :en }
-      assert_redirected_to root_path
+      assert_redirected_to admin_root_path
     end
   end
 

--- a/test/controllers/admin/groups_controller_test.rb
+++ b/test/controllers/admin/groups_controller_test.rb
@@ -18,13 +18,13 @@ class Admin::GroupsControllerTest < ActionController::TestCase
   test "a signed out user should not be able to load the group page" do
     sign_in users(:user)
     get :index, locale: :en
-    assert_redirected_to root_path
+    assert_redirected_to admin_root_path
   end
 
   test "a signed in user should not be able to load the group page" do
     sign_in users(:user)
     get :index, locale: :en
-    assert_redirected_to root_path
+    assert_redirected_to admin_root_path
   end
 
   test "an admin should be able to load the group page" do

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -19,48 +19,49 @@ class Admin::SettingsControllerTest < ActionController::TestCase
     # TODO: Temporarily disabled these cause they were failing even thought the
     # functionality works okay in the browser
 
-    # test "an #{unauthorized} should NOT be able to modify the settings" do
-    #   sign_in users(unauthorized.to_sym)
-    #   put :update_settings,
-    #     'settings.site_name' => 'Helpy Support 2',
-    #     'settings.parent_site' => 'http://helpy.io/2',
-    #     'settings.parent_company' => 'Helpy 2',
-    #     'settings.site_tagline' => 'Support',
-    #     'settings.google_analytics_id' => 'UA-0000-21'
-    #   assert_redirected_to root_path
-    #   assert_not_equal 'Helpy Support 2', AppSettings['settings.site_name']
-    #   assert_not_equal 'http://helpy.io/2', AppSettings['settings.parent_site']
-    #   assert_not_equal 'Helpy 2', AppSettings['settings.parent_company']
-    #   assert_not_equal 'Support', AppSettings['settings.site_tagline']
-    #   assert_not_equal 'UA-0000-21', AppSettings['settings.google_analytics_id']
-    # end
-    #
-    # test "an #{unauthorized} should NOT be able to load the settings" do
-    #   sign_in users(unauthorized.to_sym)
-    #   get :index
-    #   assert_redirected_to root_path
-    # end
+    test "an #{unauthorized} should NOT be able to modify the settings" do
+      sign_in users(unauthorized.to_sym)
+      put :update_general,
+        'settings.site_name' => 'Helpy Support 2',
+        'settings.parent_site' => 'http://helpy.io/2',
+        'settings.parent_company' => 'Helpy 2',
+        'settings.site_tagline' => 'Support',
+        'settings.google_analytics_id' => 'UA-0000-21'
+      assert_not_equal 'Helpy Support 2', AppSettings['settings.site_name']
+      assert_not_equal 'http://helpy.io/2', AppSettings['settings.parent_site']
+      assert_not_equal 'Helpy 2', AppSettings['settings.parent_company']
+      assert_not_equal 'Support', AppSettings['settings.site_tagline']
+      assert_not_equal 'UA-0000-21', AppSettings['settings.google_analytics_id']
+      assert_redirected_to admin_root_path
+
+    end
+
+    test "an #{unauthorized} should NOT be able to load the settings" do
+      sign_in users(unauthorized.to_sym)
+      get :index
+      assert_redirected_to admin_root_path
+    end
   end
 
   test 'an admin should be able to modify settings' do
     sign_in users(:admin)
-    xhr :put, :update_settings,
+    put :update_general,
       'settings.site_name' => 'Helpy Support 2',
       'settings.parent_site' => 'http://helpy.io/2',
       'settings.parent_company' => 'Helpy 2',
       'settings.site_tagline' => 'Support',
       'settings.google_analytics_id' => 'UA-0000-21'
-    assert_response :success
     assert_equal 'Helpy Support 2', AppSettings['settings.site_name']
     assert_equal 'http://helpy.io/2', AppSettings['settings.parent_site']
     assert_equal 'Helpy 2', AppSettings['settings.parent_company']
     assert_equal 'Support', AppSettings['settings.site_tagline']
     assert_equal 'UA-0000-21', AppSettings['settings.google_analytics_id']
+    assert_redirected_to admin_general_settings_path
   end
 
   test 'an admin should be able to modify design' do
     sign_in users(:admin)
-    xhr :put,:update_settings,
+    put :update_design,
       'design.header_logo' => 'logo2.png',
       'design.footer_mini_logo' => 'logo2.png',
       'design.favicon' => 'favicon2.ico',
@@ -69,7 +70,6 @@ class Admin::SettingsControllerTest < ActionController::TestCase
       'css.link_color' => '000000',
       'css.form_background' => '000000',
       'css.still_need_help' => '000000'
-    assert_response :success
     assert_equal 'logo2.png', AppSettings['design.header_logo']
     assert_equal 'logo2.png', AppSettings['design.footer_mini_logo']
     assert_equal 'favicon2.ico', AppSettings['design.favicon']
@@ -78,13 +78,14 @@ class Admin::SettingsControllerTest < ActionController::TestCase
     assert_equal '000000', AppSettings['css.link_color']
     assert_equal '000000', AppSettings['css.form_background']
     assert_equal '000000', AppSettings['css.still_need_help']
+    assert_redirected_to admin_design_settings_path
   end
 
   test 'an admin should be able to change the theme' do
     AppSettings['theme.active'] = ''
 
     sign_in users(:admin)
-    put :update_settings,
+    put :update_theme,
       'theme.active' => 'flat'
     assert_equal 'flat', AppSettings['theme.active']
   end
@@ -94,23 +95,24 @@ class Admin::SettingsControllerTest < ActionController::TestCase
     # first, toggle off all locales
     AppSettings['i18n.available_locales'] = ''
 
-    xhr :put, :update_settings,
+    xhr :put, :update_i18n,
       'i18n.available_locales' => ['en', 'es', 'de', 'fr', 'et', 'ca', 'ru', 'ja', 'zh-cn', 'zh-tw', 'pt', 'nl']
 
-    assert_response :success
     assert_equal ['en', 'es', 'de', 'fr', 'et', 'ca', 'ru', 'ja', 'zh-cn', 'zh-tw', 'pt', 'nl'], AppSettings['i18n.available_locales']
+    assert_redirected_to admin_i18n_settings_path
   end
 
   test 'an admin should be able to toggle display of the widget on and off' do
     sign_in users(:admin)
     # toggle it off
     AppSettings['widget.show_on_support_site'] = 0
-    xhr :put, :update_settings, 'widget.show_on_support_site' => '1'
+    xhr :put, :update_widget, 'widget.show_on_support_site' => '1'
     assert_equal '1', AppSettings['widget.show_on_support_site']
+    assert_redirected_to admin_widget_settings_path
   end
 
   test 'an admin should be able to turn email delivery on and off' do
-    put :update_settings,
+    put :update_email,
       'email.send_email' => 'false'
 
     # TODO: Refactor this into an integration test
@@ -121,7 +123,7 @@ class Admin::SettingsControllerTest < ActionController::TestCase
 
   test 'an admin should be able to add mail settings' do
     sign_in users(:admin)
-    xhr :put, :update_settings,
+    put :update_email,
       'email.admin_email' => 'test@test.com',
       'email.from_email' => 'test@test.com',
       'email.mail_service' => 'mailgun',
@@ -130,8 +132,6 @@ class Admin::SettingsControllerTest < ActionController::TestCase
       'email.smtp_mail_password' => '1234',
       'email.mail_port' => '587',
       'email.mail_domain' => 'something.com'
-    assert_response :success
-
     assert_equal 'test@test.com', AppSettings['email.admin_email']
     assert_equal 'test@test.com', AppSettings['email.from_email']
     assert_equal 'mailgun', AppSettings['email.mail_service']
@@ -140,28 +140,44 @@ class Admin::SettingsControllerTest < ActionController::TestCase
     assert_equal '1234', AppSettings['email.smtp_mail_password']
     assert_equal '587', AppSettings['email.mail_port']
     assert_equal 'something.com', AppSettings['email.mail_domain']
+    assert_redirected_to admin_email_settings_path
+  end
+
+  test "should send a test email when updating mail settings" do
+    sign_in users(:admin)
+
+    assert_difference "ActionMailer::Base.deliveries.size", 1 do
+      put :update_email,
+        'email.admin_email' => 'test@test.com',
+        'email.from_email' => 'test@test.com',
+        'email.mail_service' => 'mailgun',
+        'email.mail_smtp' => 'mail.test.com',
+        'email.smtp_mail_username' => 'test-login',
+        'email.smtp_mail_password' => '1234',
+        'email.mail_port' => '587',
+        'email.mail_domain' => 'something.com',
+        'send_test' => '1'
+    end
   end
 
   test 'an admin should be able to add a cloudinary key' do
     sign_in users(:admin)
-    xhr :put, :update_settings,
+    put :update_integration,
       'cloudinary.cloud_name' => 'something',
       'cloudinary.api_key' => 'something',
       'cloudinary.api_secret' => 'something'
-    assert_response :success
     assert_equal 'something', AppSettings['cloudinary.cloud_name']
     assert_equal 'something', AppSettings['cloudinary.api_key']
     assert_equal 'something', AppSettings['cloudinary.api_secret']
-    get :index
+    assert_redirected_to admin_integration_settings_path
   end
 
   test 'the updated cloudinary keys should be persisted into the api object' do
     sign_in users(:admin)
-    xhr :put, :update_settings,
+    put :update_integration,
       'cloudinary.cloud_name' => 'something',
       'cloudinary.api_key' => 'something',
       'cloudinary.api_secret' => 'something'
-    assert_response :success
     get :index
     assert_equal 'something', Cloudinary.config.cloud_name
     assert_equal 'something', Cloudinary.config.api_key

--- a/test/mailers/post_mailer_test.rb
+++ b/test/mailers/post_mailer_test.rb
@@ -64,4 +64,20 @@ class PostMailerTest < ActionMailer::TestCase
       assert_equal('bcc@test.com', ActionMailer::Base.deliveries[0].bcc[0])
     end
   end
+
+  test 'Post mailer includes the header and footer' do
+    header = Doc.create(title: 'Customer_header', body: 'test header', category_id: 2)
+    footer = Doc.create(title: 'Customer_footer', body: '%ticket_link%', category_id: 2)
+
+    topic = Topic.first
+    post = topic.posts.create(body: "a response to %customer_name%", cc: "cc@test.com", bcc: "bcc@test.com", kind: 'reply', user_id: '1')
+    email = PostMailer.new_post(post.id)
+
+    assert_emails 1 do
+      email.deliver_now
+      assert_equal true, email.html_part.body.to_s.include?(header.body)
+      assert_equal true, email.html_part.body.to_s.include?(I18n.translate('view_online', default: 'View this online:'))
+      assert_equal true, email.html_part.body.to_s.include?(topic.user.name)
+    end
+  end
 end

--- a/test/mailers/previews/test_mailer_preview.rb
+++ b/test/mailers/previews/test_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/test_mailer
+class TestMailerPreview < ActionMailer::Preview
+
+end

--- a/test/mailers/test_mailer_test.rb
+++ b/test/mailers/test_mailer_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class TestMailerTest < ActionMailer::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
closes #876
closes #500 

Adds the ability to create a custom html header and footer for outgoing ticket emails sent to the customer.  This works by using a special named doc, so there is a rake task you should run to seed/set up the records: `bundle exec rake update:enable_templates`

There is also support for two tokens- `%customer_name% will populate with the customers name (best if used in combination with a common reply).  `%ticket_link%` will populate with a link to the ticket (used in the footer typically.