### PR TITLE
Dev/824 clientside validations not working for groups new edit form

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,7 @@ cache: bundler
 addons:
     code_climate:
         repo_token: 8aed69acf532241f5281042dc5b1a5d89ea9206773d079ce2de838a28f0f5041
+    chrome: stable
+    apt:
+      packages:
+        - chromium-chromedriver

--- a/Gemfile
+++ b/Gemfile
@@ -189,6 +189,7 @@ group :test do
   gem 'factory_girl_rails'
   gem 'capybara'
   gem 'selenium-webdriver'
+  gem 'chromedriver-helper'
   gem 'launchy'
   gem "codeclimate-test-reporter",require: nil
   gem 'simplecov', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,8 @@ GEM
       activerecord (>= 3.2, < 6.0)
       rake (~> 10.4)
     ansi (1.5.0)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (6.0.4)
     ast (2.3.0)
     attachinary (1.3.1)
@@ -122,8 +124,11 @@ GEM
     celluloid (0.16.0)
       timers (~> 4.0.0)
     chartkick (2.2.2)
-    childprocess (0.6.2)
+    childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (2.1.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     client_side_validations (4.2.3)
       jquery-rails (>= 3.1.2, < 5.0.0)
       js_regex (~> 1.0, >= 1.0.9)
@@ -190,7 +195,7 @@ GEM
       i18n (~> 0.5)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.17)
+    ffi (1.9.25)
     font-awesome-sass (5.0.13)
       sassc (>= 1.11)
     foundation_emails (2.2.1.0)
@@ -272,6 +277,7 @@ GEM
     inky-rb (1.3.7.2)
       foundation_emails (~> 2)
       nokogiri
+    io-like (0.3.0)
     jbuilder (2.4.1)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
@@ -489,7 +495,7 @@ GEM
       sexp_processor (~> 4.0)
     ruby_parser (3.8.1)
       sexp_processor (~> 4.1)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     safe_yaml (1.0.4)
     sass (3.4.25)
     sass-rails (5.0.6)
@@ -509,10 +515,9 @@ GEM
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
     selectize-rails (0.12.1)
-    selenium-webdriver (3.2.2)
+    selenium-webdriver (3.14.0)
       childprocess (~> 0.5)
-      rubyzip (~> 1.0)
-      websocket (~> 1.0)
+      rubyzip (~> 1.2)
     sexp_processor (4.7.0)
     shoulda (3.5.0)
       shoulda-context (~> 1.0, >= 1.0.1)
@@ -589,7 +594,6 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
-    websocket (1.2.4)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -616,6 +620,7 @@ DEPENDENCIES
   capybara
   carrierwave (~> 1.0.0)
   chartkick
+  chromedriver-helper
   client_side_validations
   client_side_validations-simple_form
   cloudinary (= 1.1.2)

--- a/app/views/admin/groups/new.html.erb
+++ b/app/views/admin/groups/new.html.erb
@@ -9,7 +9,7 @@
   </div>
   <div class="settings-panel row">
     <div class="col-md-12 col-sm-12 col-xs-12">
-      <%= simple_form_for @team, url: admin_groups_path, method: 'post', remote: false do |f| %>
+      <%= simple_form_for @team, url: admin_groups_path, method: 'post', validate: true, remote: false do |f| %>
         <%= render "form", f: f  %>
       <% end %>
     </div>

--- a/config/initializers/backport_pg_10_support_to_rails_4.rb
+++ b/config/initializers/backport_pg_10_support_to_rails_4.rb
@@ -1,0 +1,46 @@
+require 'active_record/connection_adapters/postgresql/schema_statements'
+
+#
+# Monkey-patch the refused Rails 4.2 patch at https://github.com/rails/rails/pull/31330
+#
+# Updates sequence logic to support PostgreSQL 10.
+#
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module SchemaStatements
+        # Resets the sequence of a table's primary key to the maximum value.
+        def reset_pk_sequence!(table, pk = nil, sequence = nil) #:nodoc:
+          unless pk && sequence
+            default_pk, default_sequence = pk_and_sequence_for(table)
+
+            pk ||= default_pk
+            sequence ||= default_sequence
+          end
+
+          if @logger && pk && !sequence
+            @logger.warn "#{table} has primary key #{pk} with no default sequence"
+          end
+
+          if pk && sequence
+            quoted_sequence = quote_table_name(sequence)
+            max_pk = select_value("SELECT MAX(#{quote_column_name pk}) FROM #{quote_table_name(table)}")
+            if max_pk.nil?
+              if postgresql_version >= 100000
+                minvalue = select_value("SELECT seqmin FROM pg_sequence WHERE seqrelid = #{quote(quoted_sequence)}::regclass")
+              else
+                minvalue = select_value("SELECT min_value FROM #{quoted_sequence}")
+              end
+            end
+
+            select_value <<-end_sql, 'SCHEMA'
+              SELECT setval(#{quote(quoted_sequence)}, #{max_pk ? max_pk : minvalue}, #{max_pk ? true : false})
+            end_sql
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/config/initializers/client_side_validations.rb
+++ b/config/initializers/client_side_validations.rb
@@ -18,3 +18,35 @@ ActionView::Base.field_error_proc = Proc.new do |html_tag, instance|
     %{<div class="field_with_errors">#{html_tag}</div>}.html_safe
   end
 end
+
+module ClientSideValidations
+  module ActionView
+    module Helpers
+      module FormHelper
+        def construct_validators
+          @validators.each_with_object({}) do |object_opts, validator_hash|
+            option_hash = object_opts[1].each_with_object({}) do |attr, result|
+              result[attr[0]] = attr[1][:options]
+            end
+
+            validation_hash =
+              if object_opts[0].respond_to?(:client_side_validation_hash)
+                object_opts[0].client_side_validation_hash(option_hash)
+              else
+                {}
+              end
+
+            option_hash.each_key do |attr|
+              # due to value of option_hash return 'Symbol', meanwhile value of validation_hash return 'String' 
+              # =>validation_hash[attr.to_sym]
+              if validation_hash[attr.to_sym]
+                validator_hash.merge!(object_opts[1][attr][:name] => validation_hash[attr.to_sym])
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/config/initializers/client_side_validations.rb
+++ b/config/initializers/client_side_validations.rb
@@ -37,10 +37,10 @@ module ClientSideValidations
               end
 
             option_hash.each_key do |attr|
-              # due to value of option_hash return 'Symbol', meanwhile value of validation_hash return 'String' 
-              # =>validation_hash[attr.to_sym]
-              if validation_hash[attr.to_sym]
-                validator_hash.merge!(object_opts[1][attr][:name] => validation_hash[attr.to_sym])
+              # attr is String type which is different type of validation_hash's keys
+              validation_hash = validation_hash.with_indifferent_access
+              if validation_hash[attr]
+                validator_hash.merge!(object_opts[1][attr][:name] => validation_hash[attr])
               end
             end
           end

--- a/test/integration/client_side_validation_for_group_new_form_test.rb
+++ b/test/integration/client_side_validation_for_group_new_form_test.rb
@@ -1,0 +1,25 @@
+require 'integration_test_helper'
+
+include Warden::Test::Helpers
+
+class ClientSideValidationForGroupNewFormTest < ActionDispatch::IntegrationTest
+  def setup
+    Capybara.current_driver = :chrome
+    Warden.test_mode!
+    set_default_settings
+    sign_in('admin@test.com')
+  end
+
+  def teardown
+    Capybara.reset_sessions!
+    Warden.test_reset!
+    Capybara.use_default_driver
+  end
+  
+  test 'browsing will throw a error if user input with nil value on new form group' do
+    visit '/admin/settings/groups/new'
+    fill_in('acts_as_taggable_on_tag[name]',  with: '')
+    click_on 'Save Settings'
+    assert page.has_content?("can't be blank")
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,7 +23,7 @@ class ActiveSupport::TestCase
 end
 
 Capybara.register_driver :chrome do |app|
-  options = Selenium::WebDriver::Chrome::Options.new(args: %w[no-sandbox headless disable-gpu])
+  options = Selenium::WebDriver::Chrome::Options.new(args: %w[no-sandbox headless disable-gpu --disable-dev-shm-usage])
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,6 +22,10 @@ class ActiveSupport::TestCase
   # Settings.send_email = false
 end
 
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new(app, :browser => :chrome)
+end
+
 class ActionController::TestCase
   include Devise::TestHelpers
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,7 +23,8 @@ class ActiveSupport::TestCase
 end
 
 Capybara.register_driver :chrome do |app|
-  Capybara::Selenium::Driver.new(app, :browser => :chrome)
+  options = Selenium::WebDriver::Chrome::Options.new(args: %w[no-sandbox headless disable-gpu])
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 
 class ActionController::TestCase


### PR DESCRIPTION
## Context
The client side validation on group new page does not work. The client site validation can't not load properly because  mismatch type when accessing hash. See file change `config/initializers/client_side_validations.rb` for more details.

## Change
- Add a monkey patching to fix the issue of mismatch type when accessing hash
- Add chrome driver for javascript integration test
- Add Integration test for the page.

## References
https://github.com/helpyio/helpy/issues/824