### PR TITLE
Use current locale to filter category

### DIFF
--- a/app/controllers/admin/internal_categories_controller.rb
+++ b/app/controllers/admin/internal_categories_controller.rb
@@ -1,7 +1,7 @@
 class Admin::InternalCategoriesController < Admin::BaseController
 
   def index
-    @categories = Category.internally.without_system_resource.ordered
+    @categories = Category.internally.without_system_resource.with_translations(I18n.locale).ordered
   end
 
   def show


### PR DESCRIPTION
## Context
The categories with multiple locales appears multiple times because the query does not filter with current locale

## Changes
Use scope to filter category with current locale

## References
https://github.com/helpyio/helpy/issues/828
