### PR TITLE
Rename 'Log in' to 'Sign in'

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -330,7 +330,7 @@ class User < ActiveRecord::Base
 
   # message to the user that is not allowed to login
   def inactive_message
-    "You are not allowed to log in!"
+    "You are not allowed to sign in!"
   end
 
   def self.register email, user_name

--- a/app/themes/flat/locales/en.yml
+++ b/app/themes/flat/locales/en.yml
@@ -80,7 +80,7 @@ en:
     get_your_copy: "Grab your copy on GitHub"
 
     # devise/sessions/new
-    login: Log in
+    login: Sign in
 
     # devise/shared/links
     forgot_password: Forgot your password?

--- a/app/themes/singular/views/devise/shared/_links.html.erb
+++ b/app/themes/singular/views/devise/shared/_links.html.erb
@@ -1,7 +1,7 @@
 <div id="devise-links" class="col-md-12 text-right">
 
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to t('devise.sessions.new.sign_in'), new_session_path(resource_name) %><br />
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,7 +1,7 @@
 <div id="devise-links" class="col-md-12 text-right">
 
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to t('devise.sessions.new.sign_in'), new_session_path(resource_name) %><br />
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>

--- a/app/views/layouts/notification.html.erb
+++ b/app/views/layouts/notification.html.erb
@@ -43,7 +43,7 @@
             <small>
               <br/><br/>
               <strong>Powered by Helpy</strong><br/>
-              Log in to adjust your notifications preferences<br/>
+              Sign in to adjust your notifications preferences<br/>
             </small>
           </center>
         </td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,7 +93,7 @@ en:
   flag: "Flag"
 
   # devise/sessions/new
-  login: Log in
+  login: Sign in
 
   # devise/shared/links
   forgot_password: Forgot your password?


### PR DESCRIPTION
Fixes #542 
This PR has changes to replace all occurrences of `Log In` to `Sign In`