### PR TITLE
Change deprecated FALSE to false in user model test

### DIFF
--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -330,7 +330,7 @@ class UserTest < ActiveSupport::TestCase
     assert_nil u.thumbnail
     assert_nil u.medium_image
     assert_nil u.large_image
-    assert_equal FALSE, u.active
+    assert_equal false, u.active
     assert_equal "change", u.email.split('@')[0]
     assert_nil u.current_sign_in_ip
     assert_nil u.last_sign_in_ip


### PR DESCRIPTION
I pulled down the repo and noticed it had FALSE which was deprecated.  I changed this to false, let me know if this is not appropriate.  It also popped with Fixnum as deprecated but I read this was more of a bug.