### PR TITLE
Remove code duplication in application_helper.rb

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -90,16 +90,12 @@ module ApplicationHelper
   def tag_listing(tags, tagging_type = "message")
     return unless tagging_type == "doc"
     tags.each do |tag|
-      # concat content_tag(:span, tag, style: badge_color_from_tag(tag),class: "label label-#{tagging_type}-tagging label-#{tag.first.downcase} #{'pull-right' if tagging_type == 'message'}")
       concat content_tag(:span, tag, class: "label label-#{tagging_type}-tagging label-#{tag.first.downcase} #{'pull-right' if tagging_type == 'message'}")
     end
   end
 
   def doc_tag_listing(tags, tagging_type = "message")
-    return unless tagging_type == "doc"
-    tags.each do |tag|
-      concat content_tag(:span, tag, class: "label label-#{tagging_type}-tagging label-#{tag.first.downcase} #{'pull-right' if tagging_type == 'message'}")
-    end
+    tag_listing(tags, tagging_type)
   end
 
   def login_with(with, redirect_to = "/#{I18n.locale}")


### PR DESCRIPTION
In `application_helper.rb` there are 2 methods `tag_listing` and `doc_tag_listing` which execute identical code. Since both are being used I left them there, but removed the duplication