### PR TITLE
Helpy IMAP

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -155,6 +155,7 @@ gem 'best_in_place', '~> 3.1'
 
 # Add onboarding component
 gem 'helpy_onboarding', path: 'vendor/helpy_onboarding'
+gem 'helpy_imap', git: 'https://github.com/helpyio/helpy_imap', branch: 'master'
 
 group :development, :test do
   # Audit Gemfile for security vulnerabilities

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/helpyio/helpy_imap
+  revision: 85f944a0d79325662c6f7e47e1a037640875f88d
+  branch: master
+  specs:
+    helpy_imap (1.0)
+      deface
+      mail
+      mailman
+      rails (~> 4.2.10)
+
 PATH
   remote: vendor/helpy_onboarding
   specs:
@@ -651,6 +662,7 @@ DEPENDENCIES
   griddler-sendgrid
   griddler-sparkpost
   groupdate
+  helpy_imap!
   helpy_onboarding!
   http_accept_language
   i18n-country-translations


### PR DESCRIPTION
Finally, IMAP is ready for Helpy.  I have taken the previous work and packaged it as a Rails Engine that you can add to your existing Helpy install, or by getting current with `master`.  This allows users who are not ready or able to upgrade to master to just add the gem instead, or skip the functionality if its not needed.

closes #810 
closes #741
closes #221
closes #179
#148