### PR TITLE
927 - Fix help center link

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -147,7 +147,21 @@ module AdminHelper
     end
   end
 
-  def helpcenter_menu
+  def helpcenter_menu_or_item
+    is_knowledgebase_and_editor = knowledgebase? && current_user.is_editor?
+    is_forum_and_agent = forums? && current_user.is_agent?
+    icon = "fas fa-book"
+
+    if is_knowledgebase_and_editor && is_forum_and_agent
+      helpcenter_dropdown
+    elsif is_knowledgebase_and_editor
+      upper_nav_item(t(:content, default: "Content"), admin_categories_path, ["categories"], ["index","show","edit","new"], icon)
+    elsif is_forum_and_agent
+      upper_nav_item(t(:communities, default: "Communities"), admin_forums_path, ["forums"], ["index","edit","new"], icon)
+    end
+  end
+
+  def helpcenter_dropdown
     content_tag :li, class: 'dropdown' do
       concat helpcenter_link
       concat helpcenter_items

--- a/app/views/layouts/_admin_header.html.erb
+++ b/app/views/layouts/_admin_header.html.erb
@@ -87,7 +87,7 @@ a.navbar-brand {
                 <%= upper_nav_item(t(:inbox, default: "Inbox"), admin_topics_path,["topics"], ['index','show'], "fas fa-inbox") if (forums? || tickets?) && current_user.is_agent? %>
                 <%= upper_nav_item(t(:reports, default: 'Reports'), admin_reports_path(interval: 7), ["reports"], ['index', 'groups', 'team'], "fas fa-chart-bar") if tickets? && current_user.is_admin? %>
                 <%= upper_nav_item(t(:users, default: 'Customers'), admin_users_path(role: 'user'), ["users"], ["index","show","edit","update"], "fas fa-users") if current_user.is_agent? %>
-                <%= helpcenter_menu if (knowledgebase? || forums?) && current_user.is_agent? %>
+                <%= helpcenter_menu_or_item %>
                 <%= content_tag(:li, link_to(t(:content, default: "Content"), admin_categories_path), class:'kblink') if knowledgebase? && current_user.role == 'editor' %>
                 <%#= content_tag(:li, link_to(t(:app_store, default: "App Store"), "http://helpy.io/store/"), class: "hidden-sm hidden-xs") if current_user.is_agent? %>
                 <%= content_tag(:li, link_to(t(:open_new_discussion, default: "New Ticket"), new_admin_topic_path), class: 'visible-xs hidden-lg hidden-md hidden-sm') if current_user.is_agent? %>


### PR DESCRIPTION
Fixes - https://github.com/helpyio/helpy/issues/927

1. When both is_knowledgebase and is_forum
![both](https://user-images.githubusercontent.com/7279519/47268092-04e27600-d56a-11e8-97bc-feeec36174f3.png)

2. only is_knowledgebase
![only knowledge base](https://user-images.githubusercontent.com/7279519/47268093-0a3fc080-d56a-11e8-8b26-f56b99dd509c.png)

3. only is_forum

![only forun](https://user-images.githubusercontent.com/7279519/47268095-1035a180-d56a-11e8-908d-8f36d48d6449.png)
