### PR TITLE
Improve Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,9 @@ ENV RAILS_ENV=production \
 RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y nodejs postgresql-client imagemagick --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && useradd --no-create-home $HELPY_USER \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --no-create-home $HELPY_USER \
   && mkdir -p $HELPY_HOME \
   && chown -R $HELPY_USER:$HELPY_USER $HELPY_HOME /usr/local/lib/ruby /usr/local/bundle
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM ruby:2.4
 
-ENV HELPY_VERSION=master \
-    RAILS_ENV=production \
+ENV RAILS_ENV=production \
     HELPY_HOME=/helpy \
     HELPY_USER=helpyuser \
     HELPY_SLACK_INTEGRATION_ENABLED=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,5 @@ RUN chown -R $HELPY_USER $HELPY_HOME
 USER $HELPY_USER
 
 COPY docker/database.yml $HELPY_HOME/config/database.yml
-COPY docker/run.sh $HELPY_HOME/run.sh
 
-CMD ["./run.sh"]
+CMD ["/bin/bash", "/helpy/docker/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,12 @@ RUN apt-get update \
 
 WORKDIR $HELPY_HOME
 
+COPY Gemfile Gemfile.lock $HELPY_HOME/
+COPY vendor $HELPY_HOME/vendor
+RUN chown -R $HELPY_USER $HELPY_HOME
+
 USER $HELPY_USER
 
-RUN git clone --branch $HELPY_VERSION --depth=1 https://github.com/helpyio/helpy.git .
 
 # add the slack integration gem to the Gemfile if the HELPY_SLACK_INTEGRATION_ENABLED is true
 # use `test` for sh compatibility, also use only one `=`. also for sh compatibility
@@ -37,6 +40,11 @@ RUN mkdir -p $HELPY_HOME/public/assets \
     && chown $HELPY_USER $HELPY_HOME/public/assets
 
 VOLUME $HELPY_HOME/public
+
+USER root
+COPY . $HELPY_HOME/
+RUN chown -R $HELPY_USER $HELPY_HOME
+USER $HELPY_USER
 
 COPY docker/database.yml $HELPY_HOME/config/database.yml
 COPY docker/run.sh $HELPY_HOME/run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV RAILS_ENV=production \
 RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y nodejs postgresql-client imagemagick --no-install-recommends \
+  && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --no-create-home $HELPY_USER \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN git clone --branch $HELPY_VERSION --depth=1 https://github.com/helpyio/helpy
 
 # add the slack integration gem to the Gemfile if the HELPY_SLACK_INTEGRATION_ENABLED is true
 # use `test` for sh compatibility, also use only one `=`. also for sh compatibility
-RUN test "$HELPY_SLACK_INTEGRATION_ENABLED" = "true" && sed -i '128i\gem "helpy_slack", git: "https://github.com/helpyio/helpy_slack.git", branch: "master"' $HELPY_HOME/Gemfile
+RUN test "$HELPY_SLACK_INTEGRATION_ENABLED" = "true" \
+    && sed -i '128i\gem "helpy_slack", git: "https://github.com/helpyio/helpy_slack.git", branch: "master"' $HELPY_HOME/Gemfile
 
 RUN bundle install
 
@@ -33,7 +34,8 @@ RUN chmod +r /usr/local/bundle/gems/griddler-mandrill-1.1.4/lib/griddler/mandril
 
 # manually create the /helpy/public/assets folder and give the helpy user rights to it
 # this ensures that helpy can write precompiled assets to it
-RUN mkdir -p $HELPY_HOME/public/assets && chown $HELPY_USER $HELPY_HOME/public/assets
+RUN mkdir -p $HELPY_HOME/public/assets \
+    && chown $HELPY_USER $HELPY_HOME/public/assets
 
 VOLUME $HELPY_HOME/public
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM ruby:2.4
 ENV RAILS_ENV=production \
     HELPY_HOME=/helpy \
     HELPY_USER=helpyuser \
-    HELPY_SLACK_INTEGRATION_ENABLED=true
+    HELPY_SLACK_INTEGRATION_ENABLED=true \
+    BUNDLE_PATH=/opt/helpy-bundle
 
 RUN apt-get update \
   && apt-get upgrade -y \
@@ -12,8 +13,8 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --no-create-home $HELPY_USER \
-  && mkdir -p $HELPY_HOME \
-  && chown -R $HELPY_USER:$HELPY_USER $HELPY_HOME /usr/local/lib/ruby /usr/local/bundle
+  && mkdir -p $HELPY_HOME $BUNDLE_PATH \
+  && chown -R $HELPY_USER:$HELPY_USER $HELPY_HOME $BUNDLE_PATH
 
 WORKDIR $HELPY_HOME
 
@@ -30,9 +31,6 @@ RUN test "$HELPY_SLACK_INTEGRATION_ENABLED" = "true" \
     && sed -i '128i\gem "helpy_slack", git: "https://github.com/helpyio/helpy_slack.git", branch: "master"' $HELPY_HOME/Gemfile
 
 RUN bundle install
-
-# Due to a weird issue with one of the gems, execute this permissions change:
-RUN chmod +r /usr/local/bundle/gems/griddler-mandrill-1.1.4/lib/griddler/mandrill/adapter.rb
 
 # manually create the /helpy/public/assets folder and give the helpy user rights to it
 # this ensures that helpy can write precompiled assets to it

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,6 @@ RUN test "$HELPY_SLACK_INTEGRATION_ENABLED" = "true" \
 
 RUN bundle install
 
-RUN touch /helpy/log/production.log && chmod 0664 /helpy/log/production.log
-
 # Due to a weird issue with one of the gems, execute this permissions change:
 RUN chmod +r /usr/local/bundle/gems/griddler-mandrill-1.1.4/lib/griddler/mandrill/adapter.rb
 

--- a/README.md
+++ b/README.md
@@ -113,12 +113,10 @@ Although not required, installing locally is highly recommended and will make it
 Docker is the recommended way to quickly test or run Helpy in production.
 
 1) Install [Docker](https://get.docker.com/) and docker-compose
-2) Edit the `docker/.env` file with the neccessary information and passwords
+2) Create config file from template `cp docker/.env.sample docker/.env` and edit `docker/.env` to match your needs
 3) Edit `docker/Caddyfile` to include your URL or turn on SSL
-4) Run `docker-compose up -d` to start all of the services
-
-_Other notes_
-You can modify `docker/run.sh` and set `DO_NOT_PREPARE` to true, which will skip compiling the assets when the docker container loads. While this makes the container start faster, it is not reccommended because this is also the step where database migrations are run. If there's an update and the migrations don't run it could lead to issues with the website throwing a lot of errors.
+4) Build Helpy from local git checkout `docker-compose build`
+5) Run `docker-compose up -d` to start all of the services
 
 **Configure Basic Settings**
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,6 @@ services:
     volumes:
       - rails-assets:/helpy/public
     env_file: docker/.env
-    #environment:
-    #  - DO_NOT_PREPARE=true
     depends_on:
       - postgres
   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     depends_on:
       - helpy
   helpy:
-    image: helpy/helpy
+    build: .
     restart: always
     networks:
       - front

--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -2,3 +2,11 @@ POSTGRES_DB=helpy_production
 POSTGRES_USER=helpy
 POSTGRES_PASSWORD=some_secure_pg_password_change_in_production
 SECRET_KEY_BASE=some_secret_key_base_change_in_production
+
+# If you set `DO_NOT_PREPARE` to true, we will skip compiling
+# the assets when the docker container loads. While this makes
+# the container start faster, it is not reccommended because
+# this is also the step where database migrations are run.
+# If there's an update and the migrations don't run it could
+# lead to issues with the website throwing a lot of errors.
+#DO_NOT_PREPARE=true

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -30,5 +30,7 @@ if [[ "$RUN_PREPARE" = "false" ]]
 fi
 
 echo "starting unicorn"
+mkdir -p log
+touch log/production.log
 
 exec bundle exec unicorn -E production -c config/unicorn.rb


### PR DESCRIPTION
This PR improves Docker support. As a result, build time decreases a lot, it's easier to use Docker for development, and less network traffic.

 - use local clone for building the image (instead of cloning remote repository)
 - use local Dockerfile to build Helpy instead of pulling remote `helpy/helpy` in `docker-compose` to make development much easier
 - copy only necessary parts in early steps of the build to improve build speed, and only in the end copy rest of the content
 - merge multiple configurations to `docker/.env{,.sample}` to make configuration easier
 - move PostgreSQL data directory to temporary volume
 - update documentation to match current status
 - etc.