### PR TITLE
Move PostgreSQL data directory to temporary volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,10 +36,12 @@ services:
       - back
     env_file: docker/.env
     volumes:
-      - ./postgres:/var/lib/postgresql/data
+      - postgres:/var/lib/postgresql/data
 
 volumes:
   rails-assets:
+    driver: local
+  postgres:
     driver: local
 
 networks:


### PR DESCRIPTION
This prevents creating `postgres` directory in the local workdir, which
the local user doesn't have permissions to access.

Note: This change moves Postgres data directory, and is backwards-incompatible. For more details, please see <https://github.com/helpyio/helpy/pull/951#issuecomment-431906912>.