### PR TITLE
Ticket permission bug

### DIFF
--- a/app/controllers/admin/topics_controller.rb
+++ b/app/controllers/admin/topics_controller.rb
@@ -233,6 +233,7 @@ class Admin::TopicsController < Admin::BaseController
     #handle array of topics
     @topics = Topic.where(id: params[:topic_ids])
     @topics.update_all(private: params[:private], forum_id: params[:forum_id])
+    @topics.each{|topic| topic.update_pg_search_document}
     bulk_post_attributes = []
 
     @topics.each do |topic|

--- a/test/controllers/admin/topics_controller_test.rb
+++ b/test/controllers/admin/topics_controller_test.rb
@@ -448,4 +448,22 @@ class Admin::TopicsControllerTest < ActionController::TestCase
     end
   end
 
+  test 'toggle_privacy clear pg search document for private topic' do
+    sign_in users(:agent)
+    topic = create(:topic, private: false)
+    refute_nil topic.pg_search_document
+    xhr :get, :toggle_privacy, { topic_ids: [topic.id], private: true, forum_id: 1}
+    assert_equal topic.reload.private, true
+    assert_nil topic.pg_search_document
+  end
+
+  test 'toggle_privacy create pg search document for public topic' do
+    sign_in users(:agent)
+    topic = create(:topic, private: true)
+    topic.reload
+    assert_nil topic.pg_search_document
+    xhr :get, :toggle_privacy, { topic_ids: [topic.id], private: false, forum_id: 4}
+    assert_equal topic.reload.private, false
+    refute_nil topic.pg_search_document
+  end
 end


### PR DESCRIPTION
## Context
* PG search does not update search document for the topic when switch from public to private because of `update_all` method which skips callbacks

## Change
* Call `update_pg_search_document` function on changes topic.

## Ticket
* https://github.com/helpyio/helpy/issues/821