### PR TITLE
Enable click-outside-to-close with keyboard shortcuts modal

### DIFF
--- a/app/assets/javascripts/shortcuts.js
+++ b/app/assets/javascripts/shortcuts.js
@@ -1,6 +1,6 @@
 Helpy.showShortcuts = function() {
   if ($('#shortcutmodal').size() === 0) {
-    $('body').append("<div id='shortcutmodal' class=\"modal\" tabindex=\"-1\" role=\"dialog\" data-backdrop=\"static\">" +
+    $('body').append("<div id='shortcutmodal' class=\"modal\" tabindex=\"-1\" role=\"dialog\" data-backdrop=\"true\">" +
         "<div class=\"modal-dialog modal-lg\">" +
         "	<div class=\"modal-content\">" +
         "		<iframe src=\"/admin/shortcuts\" width=\"100%\" height=\"900\" frameborder=\"no\" scrolling=\"auto\"></iframe>" +


### PR DESCRIPTION
The modal was defined to be static and there was no button to close the modal. Therefore the only way to close it was by Esc-key.

With this PR, clicking outside of the modal closes the modal.

If this is not the desired way of closing the modal, I can implement something else that would make the UX better. For example a big X in the corner.