### PR TITLE
test: with theme specified in ENV HELPY_THEME

### DIFF
--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -30,7 +30,7 @@ class HomeControllerTest < ActionController::TestCase
 
   test "a browsing user should see the correct template when visiting the home page" do
     get :index, locale: :en
-    assert_template layout: "layouts/helpy"
+    assert_template layout: "layouts/#{AppSettings['theme.active']}"
   end
 
   # There are two categories in the test data, one is featured on home page

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -108,7 +108,7 @@ def set_default_settings
   AppSettings['cloudinary.cloud_name'] = ''
   AppSettings['cloudinary.api_key'] = ''
   AppSettings['cloudinary.api_secret'] = ''
-  AppSettings['theme.active'] = 'helpy'
+  AppSettings['theme.active'] = ENV['HELPY_THEME'] || 'helpy'
   AppSettings['onboarding.complete'] = '1'
 
   # assign all agents to receive notifications


### PR DESCRIPTION
It is easy to break things in themes - for example with a typo in your views.
Allow running tests with a theme set in the HELPY_THEME environment variable.

Obviously some themes will not implement all functionality
or use different markup so that tests fail due to that.
Thinking about adding a skip_for_themes test helper for that.

For now being able to see which tests are failing for a given theme is helpful for me - maybe for others too.