### PR TITLE
Move "Internal Content" -button to admin header

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -138,7 +138,6 @@ module AdminHelper
   def help_items
     content_tag :ul, class: 'dropdown-menu' do
       concat content_tag(:li, link_to(t(:get_help, default: "Get Help"), "http://support.helpy.io/"), target: "blank")
-      concat content_tag(:li, link_to(t(:internal_content, default: "Internal Content"), admin_internal_categories_path), class:'kblink') if knowledgebase?
       concat content_tag(:li, link_to(t(:report_bug, default: "Report a Bug"), "http://github.com/helpyio/helpy/issues"), target: "blank")
       concat content_tag(:li, link_to(t(:suggest_feature, default: "Suggest a Feature"), "http://support.helpy.io/en/community/4-feature-requests/topics"), target: "blank")
       concat content_tag(:li, link_to(t(:shortcuts, default: "Keyboard Shortcuts"), "#", class: 'keyboard-shortcuts-link'), target: "blank") if current_user.is_agent?

--- a/app/views/layouts/_admin_header.html.erb
+++ b/app/views/layouts/_admin_header.html.erb
@@ -89,6 +89,7 @@ a.navbar-brand {
                 <%= upper_nav_item(t(:users, default: 'Customers'), admin_users_path(role: 'user'), ["users"], ["index","show","edit","update"], "fas fa-users") if current_user.is_agent? %>
                 <%= helpcenter_menu_or_item %>
                 <%= content_tag(:li, link_to(t(:content, default: "Content"), admin_categories_path), class:'kblink') if knowledgebase? && current_user.role == 'editor' %>
+                <%= upper_nav_item(t(:internal_content, default: "Internal Content"), admin_internal_categories_path, ["internal_categories"], ["index","show"], "fas fa-book") %>
                 <%#= content_tag(:li, link_to(t(:app_store, default: "App Store"), "http://helpy.io/store/"), class: "hidden-sm hidden-xs") if current_user.is_agent? %>
                 <%= content_tag(:li, link_to(t(:open_new_discussion, default: "New Ticket"), new_admin_topic_path), class: 'visible-xs hidden-lg hidden-md hidden-sm') if current_user.is_agent? %>
                 <%= content_tag(:li, link_to(t(:settings, default: "Settings"), admin_settings_path), class: 'visible-xs hidden-lg hidden-md hidden-sm') if current_user.is_admin? %>


### PR DESCRIPTION
This PR will move the "Internal Content" -button from admin help menu to admin header. This way, it's easier to discover internal content page.

Before:
![Screenshot from 2019-04-25 11-38-40](https://user-images.githubusercontent.com/43742796/56722147-1726b200-674f-11e9-927b-10175e3234ae.png)

After:
![Screenshot from 2019-04-25 11-49-26](https://user-images.githubusercontent.com/43742796/56722677-3e31b380-6750-11e9-8ec7-1d524bc1b720.png)
