### PR TITLE
Adds anti-spam features

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -124,11 +124,14 @@ Helpy.admin = function(){
     var chosen = $(".settings-section.email select").val();
       $('.imap-settings').addClass('hidden');
       $('.pop3-settings').addClass('hidden');
+      $('.spam-protection').removeClass('hidden');
     if (chosen == 'pop3' ){
       $('.pop3-settings').removeClass('hidden');
+      $('.spam-protection').addClass('hidden');
     }
     if (chosen == 'imap' ){
       $('.imap-settings').removeClass('hidden');
+      $('.spam-protection').addClass('hidden');
     }
   });
 

--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -311,19 +311,25 @@ Helpy.ready = function(){
   });
 
   $('.multiple-update').off().on('click', function(){
-    // collect array of all checked boxes
-    var topic_ids = {};
     var str = $(this).attr('href');
-    $('.topic-checkbox:checked').each(function(i){
-      topic_ids[i] = $(this).val();
-    });
-    // modify link to include array
-    $.each(topic_ids, function(i){
-      str = str + "&topic_ids[]=" + topic_ids[i];
-    });
-    $(this).attr('href', str);
+    if ($('#select_all').is(':checked')) {
+      str = str + "&affect=all";
+      $(this).attr('href', str);
+    } else {
+      // collect array of all checked boxes
+      var topic_ids = {};
+      $('.topic-checkbox:checked').each(function(i){
+        topic_ids[i] = $(this).val();
+      });
+      // modify link to include array
+      $.each(topic_ids, function(i){
+        str = str + "&topic_ids[]=" + topic_ids[i];
+      });
+      $(this).attr('href', str);
+    }
     // return true to follow the link
     return true;
+
   });
 
   // Topic voting widget animation

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -116,14 +116,15 @@ class Admin::BaseController < ApplicationController
       topics = Topic.all
       @admins = User.agents.includes(:topics)
     end
-    @new = topics.unread.count
-    @unread = topics.unread.count
-    @pending = Topic.mine(current_user.id).pending.count
-    @open = topics.open.count
-    @active = topics.active.count
-    @mine = Topic.active.mine(current_user.id).count
+    @new = topics.unread.size
+    @unread = topics.unread.size
+    @pending = Topic.mine(current_user.id).pending.size
+    @open = topics.open.size
+    @active = topics.active.size
+    @mine = Topic.active.mine(current_user.id).size
     # @closed = topics.closed.count
-    # @spam = topics.spam.count
+    @spam = topics.spam.size
+    @trash = topics.trash.size
   end
 
   def set_categories_and_non_featured

--- a/app/controllers/admin/topics_controller.rb
+++ b/app/controllers/admin/topics_controller.rb
@@ -603,7 +603,6 @@ class Admin::TopicsController < Admin::BaseController
   def get_topics_cohort
     #  If affect is all, that means all matching tickets should be bulk updated
     if params[:affect].present? && params[:affect] == "all"
-      binding.pry
       if params[:status].present?
         @topics = Topic.where(current_status: params[:status]).all
       elsif params[:q].present?
@@ -612,7 +611,6 @@ class Admin::TopicsController < Admin::BaseController
 
     # Select topics from params
     else
-      binding.pry
       @topics = Topic.where(id: params[:topic_ids]).all
     end
     

--- a/app/controllers/admin/topics_controller.rb
+++ b/app/controllers/admin/topics_controller.rb
@@ -445,6 +445,19 @@ class Admin::TopicsController < Admin::BaseController
     render layout: 'admin-plain'
   end
 
+  def empty_trash
+    EmptyTrashJob.perform_later
+
+    fetch_counts
+    get_all_teams
+    get_tickets_by_status
+    flash[:notice] = I18n.t(:trash_emptied, default: "The trash has been emptied.")
+
+    respond_to do |format|
+      format.js
+    end
+  end
+
   protected
 
   def create_customer_conversation

--- a/app/jobs/delete_topic_job.rb
+++ b/app/jobs/delete_topic_job.rb
@@ -1,0 +1,8 @@
+class DeleteTopicJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(topic_id)
+    topic = Topic.find(topic_id)
+    topic.destroy
+  end
+end

--- a/app/jobs/empty_trash_job.rb
+++ b/app/jobs/empty_trash_job.rb
@@ -1,0 +1,10 @@
+class EmptyTrashJob < ActiveJob::Base
+  queue_as :default
+
+  def perform
+    topics = Topic.trash.all
+    topics.each do |topic|
+      DeleteTopicJob.perform_later(topic.id)
+    end
+  end
+end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -19,9 +19,9 @@ class NotificationMailer < ApplicationMailer
 
   def new_notification(topic_id, notifiable_users)
     return if notifiable_users.count == 0
-
     @topic = Topic.find(topic_id)
     return if @topic.user.nil?
+    return if @topic.spam_score.to_f > AppSettings["email.spam_assassin_filter"].to_f
     
     @posts = @topic.posts.where.not(id: @topic.posts.last.id).reverse
     @user = @topic.user

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -84,7 +84,7 @@ class Post < ActiveRecord::Base
       else
         logger.info('waiting on admin')
         waiting_on = "admin"
-        status = "pending" unless self.topic.current_status == 'new'
+        status = "pending" unless ['new','trash','spam'].include? self.topic.current_status
       end
     end
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -63,6 +63,7 @@ class Topic < ActiveRecord::Base
   scope :mine, -> (user) { where(assigned_user_id: user) }
   scope :closed, -> { where(current_status: "closed") }
   scope :spam, -> { where(current_status: "spam")}
+  scope :trash, -> { where(current_status: "trash")}
   scope :assigned, -> { where.not(assigned_user_id: nil) }
 
   scope :chronologic, -> { order('updated_at DESC') }

--- a/app/views/admin/settings/email.html.erb
+++ b/app/views/admin/settings/email.html.erb
@@ -7,7 +7,6 @@
       <%= f.select 'email.mail_service',
         options_for_select([['Mailgun', 'mailgun'],['Sendgrid', 'sendgrid'],['Mandrill','mandrill'],['Postmark','postmark'],['Sparkpost','sparkpost']], AppSettings['email.mail_service']),
         label: t('mail_service', default: "Inbound Mail Service Provider") %>
-
       <%= f.form_group 'email.send_email', label: { text: t('send_email', default: "Enable Outbound (SMTP) Email") }, class: 'send-email-toggle' do %>
         <%= f.radio_button 'email.send_email', false, label: t('boolean_no', default: "No"), checked: "#{AppSettings['email.send_email']}" == 'false', class: 'send-email' %>
         <%= f.radio_button 'email.send_email', true, label: t('boolean_yes', default: "Yes"), checked: "#{AppSettings['email.send_email']}" == 'true', class: 'send-email' %>
@@ -23,6 +22,10 @@
         <%= f.check_box 'send_test', { checked: true, label: t('send_test_email', default: "Send a test email to administrators"), label_class: 'full-width', class: 'bs-toggle', data: { size: 'mini' } } %>
 
       </div>
+    </div>
+    <div class="settings-section spam-protection" data-hook="spam_protection">
+      <%= f.text_field 'email.spam_assassin_reject', label: 'Reject incoming email SpamAssassin threshold', value: AppSettings['email.spam_assassin_reject'] %>
+      <%= f.text_field 'email.spam_assassin_filter', label: 'Filter to Spam incoming email SA threshold ', value: AppSettings['email.spam_assassin_filter'] %>
     </div>
     <div class="submit-section">
       <%= f.submit "Save Settings", class: 'btn btn-warning' %>

--- a/app/views/admin/topics/_ticket_stats.html.erb
+++ b/app/views/admin/topics/_ticket_stats.html.erb
@@ -8,4 +8,10 @@
   <%= render partial: 'admin/topics/nav_item', locals: { status: 'new', label: t(:new), count: @new } %>
   <%= render partial: 'admin/topics/nav_item', locals: { status: 'mine', label: t(:mine), count: @mine } %>
   <%= render partial: 'admin/topics/nav_item', locals: { status: 'pending', label: t(:pending), count: @pending } %>
+  <% if current_user.is_admin? %>
+    <li>&nbsp;</li>
+    <li>&nbsp;</li>
+    <%= render partial: 'admin/topics/nav_item', locals: { status: 'spam', label: t(:spam), count: @spam } %>
+    <%= render partial: 'admin/topics/nav_item', locals: { status: 'trash', label: t(:trash), count: @trash } %>
+  <% end %>
 </ul>

--- a/app/views/admin/topics/_tickets.html.erb
+++ b/app/views/admin/topics/_tickets.html.erb
@@ -35,6 +35,11 @@
 
   </tbody>
   <tbody id="multiple-edit" style="display:none;">
+    <% if params[:q].present? %>
+    <tr>
+      <td colspan="3"><%= check_box_tag :select_all %> <span class="tiny-header">Select all <%= @topics.total_count %> matching tickets</span></td>
+    </tr>
+    <% end %>
     <tr>
 
       <td colspan="3">
@@ -45,11 +50,11 @@
               <%= t(:change_status, default: 'Change Status') %> <span class='caret'></span>
             </span>
             <ul class="dropdown-menu ticket-controls" role="menu">
-              <li><%= link_to t(:mark_closed, default: 'Mark Closed'), admin_update_topic_path(change_status: 'closed', status: params[:status]), :remote => true, class: 'multiple-update'  %></li>
-              <li><%= link_to t(:reopen, default: 'Reopen'), admin_update_topic_path(change_status: 'reopen', status: params[:status]), :remote => true, class: 'multiple-update'  %></li>
-              <li><%= link_to t(:mark_new, default: 'Mark New'), admin_update_topic_path(change_status: 'new', status: params[:status]), :remote => true, class: 'multiple-update'  %></li>
-              <li><%= link_to t(:mark_spam, default: 'Mark Spam'), admin_update_topic_path(change_status: 'spam', status: params[:status]), :remote => true, class: 'multiple-update'  %></li>
-              <li><%= link_to t(:trash, default: 'Trash'), admin_update_topic_path(change_status: 'trash', status: params[:status]), :remote => true, class:'multiple-update' %></li>
+              <li><%= link_to t(:mark_closed, default: 'Mark Closed'), admin_update_topic_path(change_status: 'closed', status: params[:status], q: params[:q]), :remote => true, class: 'multiple-update'  %></li>
+              <li><%= link_to t(:reopen, default: 'Reopen'), admin_update_topic_path(change_status: 'reopen', status: params[:status], q: params[:q]), :remote => true, class: 'multiple-update'  %></li>
+              <li><%= link_to t(:mark_new, default: 'Mark New'), admin_update_topic_path(change_status: 'new', status: params[:status], q: params[:q]), :remote => true, class: 'multiple-update'  %></li>
+              <li><%= link_to t(:mark_spam, default: 'Mark Spam'), admin_update_topic_path(change_status: 'spam', status: params[:status], q: params[:q]), :remote => true, class: 'multiple-update'  %></li>
+              <li><%= link_to t(:trash, default: 'Trash'), admin_update_topic_path(change_status: 'trash', status: params[:status], q: params[:q]), :remote => true, class:'multiple-update' %></li>
             </ul>
           </span>
 

--- a/app/views/admin/topics/_tickets.html.erb
+++ b/app/views/admin/topics/_tickets.html.erb
@@ -5,6 +5,9 @@
   <%#=  t(:discussions, default: "Discussions") + ": #{strip_tags(t(@status.to_sym)) if @status.present?} " %>
   <%= @header.present? ? raw(@header) : t(:discussions, default: "Discussions") + ": #{strip_tags(t(@status.to_sym, default: @status)) if @status.present?} " %>
   <div class="pull-right nav-new-button">
+    <%= link_to  "Empty Trash", admin_empty_trash_path, 
+        data: { confirm: t(:empty_trash_warning, default: "Are you sure you want to empty the trash? This will permanently delete all tickets in the trash.") },
+        class: 'btn btn-default', remote: true if params[:status] == 'trash' && current_user.is_admin? %>
     <%= link_to t(:open_new_discussion, default: "Open Discussion"), new_admin_topic_path,
         remote: true, class: 'btn btn-primary' %>
   </div>

--- a/app/views/admin/topics/empty_trash.js
+++ b/app/views/admin/topics/empty_trash.js
@@ -1,0 +1,36 @@
+$('#tickets').html("<%= escape_javascript(render 'admin/topics/tickets') %>");
+$('.ticket-stats').html("<%= j render 'admin/topics/ticket_stats' %>");
+$('#user-info').html("<%= j render 'admin/users/user_info_horizontal' if @user %>");
+// $('#ticket-page-title').show().html("<%= t(:discussions, default: 'Discussions') %>: <% ticket_page_title %>");
+$(document).prop('title', "<%= admin_title %> <%= t(:discussions, default: 'Discussions') %>: <%= @status.titleize if @status %>");
+history.pushState(null, null, '<%= admin_topics_path(status: "active") %>');
+
+Helpy.current_status_view = '<%= @status %>';
+Helpy.current_page_view = '<%= params[:page] %>';
+Helpy.current_box_id = '<%= @box.present? ? @box.id : '' %>';
+
+// Empty ticket search field and show
+$('#q').val('');
+
+// Update timestamps
+$('.last-active time[data-time-ago]').timeago();
+
+// Send ping to GA
+ga('send', 'pageview');
+
+// jQuery hook
+Helpy.ready();
+Helpy.track();
+Helpy.logHistory();
+Helpy.ticketMenu();
+
+// RTL changes?
+<%= "Helpy.rtl();" if rtl? %>
+
+// Update bootstrap_flash
+$('.flash-wrapper').html("<%= j bootstrap_flash %>");
+// Autoclose alert messages in admin
+$(".alert").delay(5000).slideUp(500, function(){
+    $(".alert").alert('close');
+});
+<% flash[:notice] = '' %>

--- a/config/initializers/default_settings.rb
+++ b/config/initializers/default_settings.rb
@@ -84,6 +84,8 @@ AppSettings.defaults["email.smtp_mail_password"] = Settings.smtp_mail_password
 AppSettings.defaults["email.mail_smtp"] = Settings.mail_smtp
 AppSettings.defaults["email.mail_port"] = Settings.mail_port
 AppSettings.defaults["email.mail_domain"]= Settings.mail_domain
+AppSettings.defaults["email.spam_assassin_reject"]= 4
+AppSettings.defaults["email.spam_assassin_filter"]= 2
 
 # notifications
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,7 @@ Rails.application.routes.draw do
     get 'topics/unassign_team' => 'topics#unassign_team', as: :unassign_team
     post 'topics/:topic_id/split/:post_id' => 'topics#split_topic', as: :split_topic
     get 'shortcuts' => 'topics#shortcuts', as: :shortcuts
+    get 'empty_trash' => 'topics#empty_trash', as: :empty_trash
 
     # SearchController Routes
     get 'search/topic_search' => 'search#topic_search', as: :topic_search
@@ -118,6 +119,7 @@ Rails.application.routes.draw do
     put 'settings/email' => 'settings#update_email', as: :update_email_settings
     put 'settings/integration' => 'settings#update_integration', as: :update_integration_settings
     get 'settings/profile' => 'settings#profile', as: :profile_settings
+    get 'settings/trash' => 'settings#trash', as: :trash_settings
 
     # Misc Routes
     post 'shared/update_order' => 'shared#update_order', as: :update_order

--- a/db/migrate/20190513145733_add_spam_score_to_topics.rb
+++ b/db/migrate/20190513145733_add_spam_score_to_topics.rb
@@ -1,0 +1,6 @@
+class AddSpamScoreToTopics < ActiveRecord::Migration
+  def change
+    add_column :topics, :spam_score, :decimal, default: 0.0
+    add_column :topics, :spam_report, :text, default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180720173011) do
+ActiveRecord::Schema.define(version: 20190513145733) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -274,6 +274,8 @@ ActiveRecord::Schema.define(version: 20180720173011) do
     t.string   "channel",          default: "email"
     t.string   "kind",             default: "ticket"
     t.integer  "priority",         default: 1
+    t.decimal  "spam_score",       default: 0.0
+    t.text     "spam_report",      default: ""
   end
 
   add_index "topics", ["kind"], name: "index_topics_on_kind", using: :btree

--- a/lib/email_processor.rb
+++ b/lib/email_processor.rb
@@ -3,15 +3,25 @@ class EmailProcessor
   def initialize(email)
     @email = email
     @tracker = Staccato.tracker(AppSettings['settings.google_analytics_id']) if google_analytics_enabled?
+    @spam_score = @email.spam_score.present? ? @email.spam_score.to_f : 0
   end
 
   def process
+
+
+
 
     # Guard clause to prevent ESPs like Sendgrid from posting over and over again
     # if the email presented is invalid and generates a 500.  Returns a 200
     # error as discussed on https://sendgrid.com/docs/API_Reference/Webhooks/parse.html
     # This error happened with invalid email addresses from PureChat
     return if @email.from[:email].match(/\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/).blank?
+
+    # Here we use a global spam score to system block spam, as well as a configurable
+    # spam score to set status to SPAM above the configured level.
+    puts "SPAM SCORE: #{@spam_score} (LIMIT: #{AppSettings["email.spam_assassin_reject"]})"
+    # Outright reject spam from creating a ticket at all
+    return if (@spam_score > AppSettings["email.spam_assassin_reject"].to_f)
 
     # Set attributes from email
     sitename = AppSettings["settings.site_name"]
@@ -25,13 +35,14 @@ class EmailProcessor
     subject = check_subject(@email.subject)
     attachments = @email.attachments
     number_of_attachments = attachments.present? ? attachments.size : 0
+    spam_report = @email.spam_report
 
     if subject.include?("[#{sitename}]") # this is a reply to an existing topic
-      EmailProcessor.create_reply_from_email(@email, email_address, email_name, subject, raw, message, token, to, sitename, cc, number_of_attachments)
+      EmailProcessor.create_reply_from_email(@email, email_address, email_name, subject, raw, message, token, to, sitename, cc, number_of_attachments, @spam_score, spam_report)
     elsif subject.include?("Fwd: ") # this is a forwarded message TODO: Expand this to handle foreign email formatting
-      EmailProcessor.create_forwarded_message_from_email(@email, subject, raw, message, token, to, cc, number_of_attachments)
+      EmailProcessor.create_forwarded_message_from_email(@email, subject, raw, message, token, to, cc, number_of_attachments, @spam_score, spam_report)
     else # this is a new direct message
-      EmailProcessor.create_new_ticket_from_email(@email, email_address, email_name, subject, raw, message, token, to, cc, number_of_attachments)
+      EmailProcessor.create_new_ticket_from_email(@email, email_address, email_name, subject, raw, message, token, to, cc, number_of_attachments, @spam_score, spam_report)
     end
 
   # rescue
@@ -74,16 +85,23 @@ class EmailProcessor
   end
 
   # Creates a new ticket from an email
-  def self.create_new_ticket_from_email(email, email_address, email_name, subject, raw, message, token, to, cc, number_of_attachments)
+  def self.create_new_ticket_from_email(email, email_address, email_name, subject, raw, message, token, to, cc, number_of_attachments, spam_score, spam_report)
+
+    # flag as spam if below spam score threshold
+    ticket_status = (spam_score > AppSettings["email.spam_assassin_filter"].to_f) ? "spam" : "new"
+
     @user = User.where("lower(email) = ?", email_address).first
     if @user.nil?
-      @user = EmailProcessor.create_user_for_email(email_address, token, email_name)
+      @user = EmailProcessor.create_user_for_email(email_address, token, email_name, ticket_status)
     end
 
     topic = Forum.first.topics.new(
       name: subject, 
       user_id: @user.id,
-      private: true
+      private: true,
+      current_status: ticket_status,
+      spam_score: spam_score,
+      spam_report: spam_report
     )
 
     if topic.save
@@ -114,16 +132,19 @@ class EmailProcessor
   end
 
   # Creates a ticket from a forwarded email
-  def self.create_forwarded_message_from_email(email, subject, raw, message, token, to, cc, number_of_attachments)
+  def self.create_forwarded_message_from_email(email, subject, raw, message, token, to, cc, number_of_attachments, spam_score, spam_report)
 
     # Parse from out of the forwarded raw body
     from = raw[/From: .*<(.*?)>/, 1]
     from_token = from.split("@")[0]
 
+    # flag as spam if below spam score threshold
+    ticket_status = (spam_score > AppSettings["email.spam_assassin_filter"].to_f) ? "spam" : "new"
+
     # scan users DB for sender email
     @user = User.where("lower(email) = ?", from).first
     if @user.nil?
-      @user = EmailProcessor.create_user_for_email(from, from_token, "")
+      @user = EmailProcessor.create_user_for_email(from, from_token, "", ticket_status)
     end
 
     #clean message
@@ -132,7 +153,10 @@ class EmailProcessor
     topic = Forum.first.topics.new(
       name: subject,
       user_id: @user.id,
-      private: true
+      private: true,
+      current_status: ticket_status,
+      spam_score: spam_score,
+      spam_report: spam_report
     )
 
     if topic.save
@@ -158,10 +182,14 @@ class EmailProcessor
   end
 
   # Adds a reply to an existing ticket thread from an email response.
-  def self.create_reply_from_email(email, email_address, email_name, subject, raw, message, token, to, sitename, cc, number_of_attachments)      
+  def self.create_reply_from_email(email, email_address, email_name, subject, raw, message, token, to, sitename, cc, number_of_attachments, spam_score, spam_report)      
+    
+    # flag as spam if below spam score threshold
+    ticket_status = (spam_score > AppSettings["email.spam_assassin_filter"].to_f) ? "spam" : "new"
+        
     @user = User.where("lower(email) = ?", email_address).first
     if @user.nil?
-      @user = EmailProcessor.create_user_for_email(email_address, token, email_name)
+      @user = EmailProcessor.create_user_for_email(email_address, token, email_name, ticket_status)
     end
 
     complete_subject = subject.split("[#{sitename}]")[1].strip
@@ -189,7 +217,7 @@ class EmailProcessor
     end
   end
 
-  def self.create_user_for_email(email_address, token, name)
+  def self.create_user_for_email(email_address, token, name, ticket_status)
     # create user
     @user = User.new
 
@@ -202,7 +230,7 @@ class EmailProcessor
     @user.password = User.create_password
 
     if @user.save
-      UserMailer.new_user(@user.id, @token).deliver_later if @user.save
+      UserMailer.new_user(@user.id, @token).deliver_later if @user.save && ticket_status != "spam"
     else
       @user = User.find(2) # just in case new user not saved, default to system user  
     end

--- a/test/factories/factories.rb
+++ b/test/factories/factories.rb
@@ -6,7 +6,29 @@ FactoryBot.define do
     subject { 'email subject' }
     header {}
     body { 'Hello!' }
+    spam_score { '0.11' }
+    spam_report { '' }
   end
+
+  factory :spam_from_unknown, class: OpenStruct do
+    to { [{ full: 'to_user@email.com', email: 'to_user@email.com', token: 'to_user', host: 'email.com', name: nil }] }
+    from { ({ token: 'spam_user', host: 'email.com', email: 'spammer_email@email.com', full: 'spammer <spam_user@email.com>', name: 'Spam User' }) }
+    subject { 'spam email subject' }
+    header {}
+    body { 'Spam' }
+    spam_score { '6.0' }
+    spam_report { 'spam report' }
+  end
+
+  factory :spam_filter, class: OpenStruct do
+    to { [{ full: 'to_user@email.com', email: 'to_user@email.com', token: 'to_user', host: 'email.com', name: nil }] }
+    from { ({ token: 'spam_user', host: 'email.com', email: 'spammer_email@email.com', full: 'spammer <spam_user@email.com>', name: 'Spam User' }) }
+    subject { 'spam email subject' }
+    header {}
+    body { 'Spam' }
+    spam_score { '3.0' }
+    spam_report { 'spam report' }
+  end  
 
   factory :email_from_includes_numbers, class: OpenStruct do
     to { [{ full: 'to_user@email.com', email: 'to_user@email.com', token: 'to_user', host: 'email.com', name: nil }] }

--- a/test/jobs/delete_topic_job_test.rb
+++ b/test/jobs/delete_topic_job_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class DeleteTopicJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/jobs/empty_trash_job_test.rb
+++ b/test/jobs/empty_trash_job_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class EmptyTrashJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This PR adds support for configuring the SpamAssassin thresholds passed through griddler from Sendgrid, Mandrill, etc.  Messages exceeding the thresholds are either rejected or moved to spam.  It also allows the trash to be emptied, and bulk actions on all matching messages in the search results.

closes #1286