### PR TITLE
changed the postgres volume to /var/lib/postgresql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - back
     env_file: docker/.env
     volumes:
-      - ./postgres:/var/lib/postgresql/data
+      - ./postgres:/var/lib/postgresql
 
 volumes:
   rails-assets:


### PR DESCRIPTION
The mountable directory should now be changed to /var/lib/postgresql. /var/lib/postgresql/data gives problems when to stop and rerun the helpy image. I kept getting the error: `/var/lib/postgresql/data exists but is not empty error and /var/lib/postgresql/data is not a valid directory try running initbd`. Try to create a docker-compose environment and bring up the containers using `docker-compose up --build -d`, add some data to the database and then stop the containers then try to start them later. Making this tweak permanently solved this recurring issue for me.
Another option is to create a **common volume for all postgres data**