### PR TITLE
Fix topic limiting in forums/id endpoint

### DIFF
--- a/app/controllers/api/v1/forums.rb
+++ b/app/controllers/api/v1/forums.rb
@@ -33,7 +33,7 @@ module API
         end
         get ":id", root: "forum" do
           forum = Forum.where(id: permitted_params[:id]).first!
-          present forum, with: Entity::Forum, topics: true
+          present forum, with: Entity::Forum, topics: true, topics_limit: permitted_params[:topics_limit]
         end
 
         # CREATE NEW FORUM


### PR DESCRIPTION
The topics_limit parameter was already added to permitted_params,
but it was not used in any way.

This commit finalizes the implementation of the topics_limit.