### PR TITLE
Resolve CRSF vulnerability when using multiple providers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
   # Brakeman security scanner
   - bundle exec brakeman -z
   # Check vulnerable gems
-  - bundle exec bundle-audit check --update
+  - bundle exec bundle-audit check --update --ignore CVE-2015-9284
   # Rubocop static code analyzer
   - bundle exec rubocop
   # SCSS analyzer

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ gem 'devise-i18n'
 gem 'devise-bootstrap-views'
 gem 'devise_invitable'
 gem 'omniauth'
+gem "omniauth-rails_csrf_protection" # TODO: remove once https://github.com/omniauth/omniauth/pull/809 is resolved
 gem 'omniauth-github'
 gem 'omniauth-twitter'
 gem 'omniauth-google-oauth2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -409,6 +409,9 @@ GEM
     omniauth-oauth2 (1.6.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.9)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     omniauth-twitter (1.4.0)
       omniauth-oauth (~> 1.1)
       rack
@@ -708,6 +711,7 @@ DEPENDENCIES
   omniauth-facebook
   omniauth-github
   omniauth-google-oauth2
+  omniauth-rails_csrf_protection
   omniauth-twitter
   paper_trail
   pg (~> 0.20.0)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -103,7 +103,7 @@ module ApplicationHelper
 
   def login_with(with, redirect_to = "/#{I18n.locale}")
     provider = (with == "google_oauth2") ? "google" : with
-    link_to(omniauth_authorize_path(:user, with.to_sym, origin: redirect_to), class: ["btn","btn-block","btn-social","oauth","btn-#{provider}"], style: "color:white;", data: {provider: "#{provider}"}) do
+    link_to(omniauth_authorize_path(:user, with.to_sym, origin: redirect_to), class: ["btn","btn-block","btn-social","oauth","btn-#{provider}"], style: "color:white;", data: {provider: "#{provider}"}, method: :post) do
       content_tag(:span, '', {class: ["fab", "fa-#{provider}"]}).html_safe + I18n.t("devise.shared.links.sign_in_with_provider", provider: provider.titleize)
     end
   end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,4 @@
+# Allow only POST to mitigate CVE-2015-9284, see 
+# https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284
+# TODO: remove once https://github.com/omniauth/omniauth/pull/809 is resolved
+OmniAuth.config.allowed_request_methods = [:post]

--- a/test/integration/sign_in_flow_test.rb
+++ b/test/integration/sign_in_flow_test.rb
@@ -62,7 +62,7 @@ class SignInFlowTest < ActionDispatch::IntegrationTest
 
   Devise.omniauth_providers.each do |provider|
     test "#{provider} login: is redirected to provider" do
-      get "/users/auth/#{provider}"
+      post "/users/auth/#{provider}"
       assert_response :redirect
     end
 


### PR DESCRIPTION
This resolves the vulnerability discussed here https://github.com/omniauth/omniauth/pull/809 by following the steps defined in the discussion.  This vulnerability only exists if you use multiple oauth providers with your Helpy implementation.  See https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284 for a summary.