### PR TITLE
Add missing translation on user deletion

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -136,7 +136,8 @@ class Admin::UsersController < Admin::BaseController
 
     respond_to do |format|
       format.html { redirect_to admin_users_path,
-        :flash => { :success => "User #{@user.name} was scheduled for permanent deletion." }}
+        flash: { success: I18n.t(:notify_user_delete, user_name: @user.name)}
+      }
       format.js { }
     end
   end

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -306,6 +306,7 @@ ar:
   notify_new_private: "تم استلام تذكرة عملاء جديدة من %{user_name}:"
   notify_new_public: "وقد نشر %{user_name} رسالة عامة جديدة:"
   notify_new_reply: "وورد رد جديد من %{user_name}:"
+  # notify_user_delete: "User %{user_name} was scheduled for permanent deletion."
   to_reply: 'الرد على هذه الرسالة مباشرة أو عبر الإنترنت:'
 
   # Notifications settings panel

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -347,6 +347,7 @@ de:
   notify_new_private: "Eine neue private Kundennachricht wurde von %{user_name} empfangen:"
   notify_new_public: "Eine neue öffentliche Kundennachricht wurde von %{user_name} veröffentlicht:"
   notify_new_reply: "Eine neue Kundenantwort wurde von %{user_name} empfangen:"
+  # notify_user_delete: "User %{user_name} was scheduled for permanent deletion."
   to_reply: 'Antworte direkt oder online auf diese Nachricht:'
 
   # Notifications settings panel

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -353,6 +353,7 @@ en:
   notify_new_private: "A new customer ticket has been received from %{user_name}:"
   notify_new_public: "A new public customer message has been posted by %{user_name}:"
   notify_new_reply: "A new customer reply has been received from %{user_name}:"
+  notify_user_delete: "User %{user_name} was scheduled for permanent deletion."
   to_reply: 'Reply to this message directly or online:'
 
   # Notifications settings panel

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -347,6 +347,7 @@ es:
   # notify_new_private: "A new customer ticket has been received from %{user_name}:"
   # notify_new_public: "A new public customer message has been posted by %{user_name}:"
   # notify_new_reply: "A new customer reply has been received from %{user_name}:"
+  notify_user_delete: "El usuario %{user_name} fue programado para su eliminación permanente."
   # to_reply: 'Reply to this message directly or online:'
 
   # Notifications settings panel

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -280,6 +280,7 @@ et:
   notify_new_private: "Uus pilet kliendilt %{user_name}:"
   notify_new_public: "Uus avalik sõnum kliendilt %{user_name}:"
   notify_new_reply: "Uus vastus kliendilt %{user_name}:"
+  # notify_user_delete: "User %{user_name} was scheduled for permanent deletion."
   to_reply: 'Vasta sellele sõnumile otse või internetis:'
 
   # Notifications settings panel

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -342,6 +342,7 @@ fa:
   notify_new_private: "یک پیغام خصوصی از طرف مشتری %{user_name} دریافت شده:"
   notify_new_public: "یک پیغام عمومی از طرف مشتری %{user_name} دریافت شده:"
   notify_new_reply: "یک پاسخ از طرف مشتری %{user_name} دریافت شده:"
+  # notify_user_delete: "User %{user_name} was scheduled for permanent deletion."
   to_reply: 'به این پیام با ایمیل یا از لینک مقابل پاسخ دهید:'
 
   # Notifications settings panel

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -346,6 +346,7 @@ fi:
   notify_new_private: "Uusi palvelupyyntö on saapunut käyttäjältä %{user_name}:"
   notify_new_public: "Uusi julkinen viesti on saapunut käyttäjältä %{user_name}:"
   notify_new_reply: "Uusi vastaus on saapunut käyttäjältä %{user_name}:"
+  # notify_user_delete: "User %{user_name} was scheduled for permanent deletion."
   to_reply: 'Vastaa tähän viestiin suoraan tai verkossa:'
 
   # Notifications settings panel

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -349,6 +349,7 @@ fr:
   notify_new_private: "Un nouveau ticket client a été reçu de la part de %{user_name} :"
   notify_new_public: "Un nouveau ticket client publique  a été posté par %{user_name} :"
   notify_new_reply: "Une nouvelle réponse d'un client a été reçue de la part de %{user_name} :"
+  # notify_user_delete: "User %{user_name} was scheduled for permanent deletion."
   to_reply: 'Répondez à ce message directement ou en ligne :'
 
   # Notifications settings panel

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -263,6 +263,7 @@ hu:
   notify_new_private: "Egy új privát kérdés érekezett erről a címről: %{user_name}:"
   notify_new_public: "Egy új publikus kérdést fel %{user_name}:"
   notify_new_reply: "Egy új ügyfélválaszt kaptunk %{user_name} felhasználótól:"
+  # notify_user_delete: "User %{user_name} was scheduled for permanent deletion."
   to_reply: 'Válaszolj erre az üzenetre közvetlenül, vagy online:'
 
   # Notifications settings panel

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -308,6 +308,7 @@ id:
   notify_new_private: "Ada tiket klien baru yang diterima dari %{user_name}:"
   notify_new_public: "Ada pesan publik klien baru yang dikirim oleh %{user_name}:"
   notify_new_reply: "Ada balasan klien yang diterima dari %{user_name}:"
+  # notify_user_delete: "User %{user_name} was scheduled for permanent deletion."
   to_reply: 'Balas pesan ini langsung atau secara online:'
 
   # Notifications settings panel

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -261,6 +261,7 @@ it:
   notify_new_private: "A new private customer message has been received from %{user_name}:"
   notify_new_public: "A new public customer message has been posted by %{user_name}:"
   notify_new_reply: "A new customer reply has been received from %{user_name}:"
+  # notify_user_delete: "User %{user_name} was scheduled for permanent deletion."
   to_reply: 'Reply to this message directly or online:'
 
   # Notifications settings panel

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -306,6 +306,7 @@ ko:
   notify_new_private: "%{user_name}에서 새로운 고객 티켓을 받았습니다 :"
   notify_new_public: "%{user_name}에서 새로운 공개 고객 메시지를 게시했습니다 :"
   notify_new_reply: "%{user_name}에서 새로운 고객 응답을 받았습니다 :"
+  # notify_user_delete: "User %{user_name} was scheduled for permanent deletion."
   to_reply: '이 메시지에 직접 또는 온라인으로 회신 :'
 
   # Notifications settings panel

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -305,6 +305,7 @@ ms:
   notify_new_private: "Terdapat tiket pelanggan baru yang diterima dari %{user_name}:"
   notify_new_public: "Terdapat mesej awam pelanggan baru yang dihantar oleh %{user_name}:"
   notify_new_reply: "Terdapat jawapan pelanggan yang diterima daripada %{user_name}:"
+  # notify_user_delete: "User %{user_name} was scheduled for permanent deletion."
   to_reply: 'Balas mesej ini secara langsung atau dalam talian:'
 
   # Notifications settings panel

--- a/config/locales/pt_BR.yml
+++ b/config/locales/pt_BR.yml
@@ -349,6 +349,7 @@ pt-br:
   notify_new_private: "A new customer ticket has been received from %{user_name}:"
   notify_new_public: "A new public customer message has been posted by %{user_name}:"
   notify_new_reply: "A new customer reply has been received from %{user_name}:"
+  # notify_user_delete: "User %{user_name} was scheduled for permanent deletion."
   to_reply: 'Reply to this message directly or online:'
 
   # Notifications settings panel


### PR DESCRIPTION
Closes #1192 

- Add the english and spanish translation for user deletion
message
- Add the notify_user_deletion key to the other locales to let the
other contributors know that we need it