### PR TITLE
Add honeypot to new ticket form

### DIFF
--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -61,3 +61,7 @@
     top: 0;
   }
 }
+
+#topic-url {
+  display: none;
+}

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -114,6 +114,11 @@ class TopicsController < ApplicationController
 
     associate_with_doc
 
+    if params[:topic][:url].present?
+      initialize_new_ticket_form_vars
+      return render :new
+    end
+
     if recaptcha_enabled? && !user_signed_in?
       unless verify_recaptcha(model: @topic)
         initialize_new_ticket_form_vars

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -82,6 +82,8 @@
         </div>
       <% end %>
 
+      <%= url_field 'topic', 'url', value: '', placeholder: 'http://', id: 'topic-url' %>
+
       <%= hidden_field_tag :client_id %>
       <%= f.hidden_field :doc_id, value: params[:doc_id] if params[:doc_id] %>
       <%= hidden_field_tag :from, 'widget' if params[:controller] == 'widget' || params[:from] == 'widget' %>

--- a/test/controllers/topics_controller_test.rb
+++ b/test/controllers/topics_controller_test.rb
@@ -273,6 +273,22 @@ class TopicsControllerTest < ActionController::TestCase
     end
   end
 
+  test 'a browsing user should not be able to create a new public topic when they fall for the honeypot' do
+    get :new, locale: :en
+    assert_response :success
+
+    assert_difference 'User.count', 0, 'No user should have been created' do
+      assert_difference 'Topic.count', 0, 'No topic should have been created' do
+        assert_difference 'Post.count', 0, 'No new post should have been created' do
+          post :create, topic: { user: { name: 'a user', email: 'anon@test.com', private: false }, name: 'some new private topic', body: 'some body text', forum_id: 3, posts_attributes: {:"0" => {body: "this is the body"}}, url: 'http://spamy.spam'}, locale: :en
+        end
+      end
+    end
+
+    assert_response :success
+    assert_select "#new_topic"
+  end
+
   test 'a browsing user should be able to create a new public topic without signing in when recaptcha enable' do
 
     # Make sure recaptcha site_key is set


### PR DESCRIPTION
Background:

Helpy gives the option to add a recaptcha to the new ticket form (topics/new). If no re-captcha is configured, we should still add some kind of honeypot anti-spam field to the new ticket form. Obviously this could be hidden if the re-captcha is displayed.


Implementation:

This commit adds a URL input to the new topic form, which will hopefully attract spammers to fill in their website. The form is hidden from regular users using `display: none`. In the controller we're then checking if the input was filled. A regular user wouldn't see the input, i.e. it should remain empty. A spammer in contrast happily adds some nonsense and we can reject the input.

When detecting a spammer we're doing the same thing as when the captcha wasn't filled properly, i.e. rendering the form again.


Potential problems:

- I am not sure, if this "feature" is a problem accessibility wise. I simply don't know if screen readers would also "show" the honeypot or not.
- I've seen this approach work reliably on other websites. However, an attacker, who's directly targetting helpy will of course be able to work around the honey pot quite easily.