### PR TITLE
Add tags API to create and manage tags

### DIFF
--- a/app/controllers/api/v1/base.rb
+++ b/app/controllers/api/v1/base.rb
@@ -18,6 +18,7 @@ module API
       mount API::V1::Search
       mount API::V1::Settings
       mount API::V1::Flags
+      mount API::V1::Tags
 
       add_swagger_documentation \
         info: {

--- a/app/controllers/api/v1/tags.rb
+++ b/app/controllers/api/v1/tags.rb
@@ -1,0 +1,81 @@
+module API
+  module V1
+    class Tags < Grape::API
+
+      before do
+        authenticate!
+        restrict_to_role %w(admin)
+      end
+
+      include API::V1::Defaults
+      resource :tags, desc: "Manage tags." do
+
+        # throttle max: 200, per: 1.minute
+
+        # LIST ALL TAGS
+        desc "List all tags", {
+          entity: Entity::Tag,
+          notes: "List all Tags"
+        }
+        get "", root: :tags do
+          tag_ids = ActsAsTaggableOn::Tagging.all.where(context: "tags", taggable_type: "Topic").includes(:tag).map {|tagging| tagging.tag.id }.uniq
+          tags = ActsAsTaggableOn::Tag.where("id IN (?)", tag_ids).order(:name)
+          present tags, with: Entity::Tag
+        end
+
+        # SHOW ONE TAG
+        desc "Show one tag", {
+          entity: Entity::Tag,
+          notes: "Returns details of one tag"
+        }
+        params do
+          requires :id, type: String, desc: "ID of the tag"
+        end
+        get ":id", root: :tag do
+          tag = ActsAsTaggableOn::Tag.find(permitted_params[:id])
+          present tag, with: Entity::Tag
+        end
+
+        # CREATE NEW TAG
+        desc "Create a new tag", {
+          entity: Entity::Tag,
+          notes: "Create a new tag"
+        }
+        params do
+          requires :name, type: String, desc: "The name of the tag"
+          requires :description, type: String, desc: "The description of the tag"
+          optional :color, type: String, desc: "The color hex code used for the tag, e.g. #ffcc33"
+        end
+        post "", root: :tags do
+          tag = ActsAsTaggableOn::Tag.new(permitted_params.slice(:name, :description, :color))
+
+          tag.save!
+          ActsAsTaggableOn::Tagging.create!(tag_id: tag.id, taggable_type: 'Topic', context: "tags")
+
+          present tag, with: Entity::Tag
+        end
+
+        # UPDATE EXISTING TAG
+        desc "Update a tag", {
+          entity: Entity::Tag,
+          notes: "Update a tag"
+        }
+        params do
+          requires :id, type: Integer, desc: "The ID of the tag you are updating"
+          requires :name, type: String, desc: "The name of the tag"
+          requires :description, type: String, desc: "The description of the tag"
+          optional :color, type: String, desc: "The color hex code used for the tag, e.g. #ffcc33"
+        end
+        patch ":id", root: :tags do
+          tag = ActsAsTaggableOn::Tag.find(permitted_params[:id])
+          tag.update!(
+            name: permitted_params[:name],
+            description: permitted_params[:description],
+            color: permitted_params[:color]
+          )
+          present tag, with: Entity::Tag
+        end
+      end
+    end
+  end
+end

--- a/app/models/entity/tag.rb
+++ b/app/models/entity/tag.rb
@@ -1,0 +1,8 @@
+module Entity
+  class Tag < Base
+    expose :id
+    expose :name, documentation: {type: 'String', desc: 'The name of the tag'}
+    expose :description, documentation: {type: 'String', desc: 'A description for the tag'}
+    expose :color, documentation: {type: 'String', desc: 'A color hex code used for the tag'}
+  end
+end

--- a/test/controllers/api/v1/tags_test.rb
+++ b/test/controllers/api/v1/tags_test.rb
@@ -1,0 +1,103 @@
+# == Schema Information
+#
+# Table name: tags
+#
+#  id                 :integer          not null, primary key
+#  name               :string
+#  description        :text
+#  color              :string
+#
+
+require 'test_helper'
+
+class API::V1::TagsTest < ActiveSupport::TestCase
+  include Rack::Test::Methods
+
+  def app
+    Rails.application
+  end
+
+  setup do
+    set_default_settings
+    @user = users(:admin)
+    @api_key = ApiKey.create(name: "Test Tags Key", user: @user)
+    @default_params = { token: @api_key.access_token }
+
+    @simple_tag = ActsAsTaggableOn::Tag.new(name: 'simple', description: nil, color: nil)
+    @full_tag = ActsAsTaggableOn::Tag.new(name: 'full', description: 'description', color: '#336699')
+
+    [@simple_tag, @full_tag].each do |tag|
+      tag.save!
+      ActsAsTaggableOn::Tagging.create!(tag_id: tag.id, taggable_type: 'Topic', context: 'tags')
+    end
+  end
+
+  test "an unauthenticated user should receive an unauthorized message" do
+    get '/api/v1/tags.json'
+
+    # Check not authorized
+    assert_equal 401, last_response.status
+  end
+
+  test "an API user should be able to return tags" do
+    get '/api/v1/tags.json', @default_params
+
+    # Check OK
+    assert last_response.ok?, "Response was #{last_response.status}, expected 200"
+
+    # Check returned value
+    objects = JSON.parse(last_response.body)
+    assert objects.length == 2, "Only #{objects.length} returned out of 2 tags"
+  end
+
+  test "an API user should be able to return a specific tag" do
+    get "/api/v1/tags/#{@simple_tag.id}.json", @default_params
+
+    # Check OK
+    assert last_response.ok?, "Response was #{last_response.status}, expected 200"
+
+    # Check returned value
+    object = JSON.parse(last_response.body)
+    assert object['id'] == @simple_tag.id
+    assert object['name'] == @simple_tag.name
+  end
+
+  test "an API user should be able to create a tag" do
+    params = {
+      name: Faker::Company.catch_phrase,
+      description: Faker::Lorem.paragraph,
+      color: Faker::Color.hex_color
+    }
+
+    post '/api/v1/tags.json', @default_params.merge(params)
+
+    object = JSON.parse(last_response.body)
+
+    assert_equal params[:name], object['name']
+  end
+
+  test "an API user should not be able to create an invalid tag" do
+    params = {
+      name: nil,
+      description: Faker::Lorem.paragraph
+    }
+
+    post '/api/v1/tags.json', @default_params.merge(params)
+
+    assert_equal 422, last_response.status
+  end
+
+  test "an API user should be able to update a tag" do
+    params = {
+      name: "Not simple anymore",
+      description: Faker::Lorem.paragraph,
+      color: "#ffcc99"
+    }
+
+    patch "/api/v1/tags/#{@simple_tag.id}.json", @default_params.merge(params)
+
+    object = JSON.parse(last_response.body)
+
+    assert_equal "Not simple anymore", object['name']
+  end
+end


### PR DESCRIPTION
Background:

Admins may manage tags using the admin UI, but they are not managable via API.


This commit adds a tags API to read, create, and update tags for admin users.

I did not implement deleting of tags, since many of the other APIs also don't implement deletion and I thought, that there might be a good reason for that.

The tags API is only available to admins, similarly to the tags admin user interface.

I'm only exposing the basic attributes of tags, that are also available in the user interface.