### PR TITLE
Show additional folders for Admin users

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -86,7 +86,7 @@ class Admin::BaseController < ApplicationController
     else
       topics_raw = params[:team].present? ? Topic.all.tagged_with(params[:team], any: true) : Topic
     end
-    
+
     # Only include cloudinary files if enabled
     topics_raw = cloudinary_enabled? ? topics_raw.includes(user: :avatar_files).chronologic : topics_raw.includes(:user).chronologic
 
@@ -101,6 +101,10 @@ class Admin::BaseController < ApplicationController
       topics_raw = Topic.active.mine(current_user.id).chronologic
     when 'pending'
       topics_raw = Topic.pending.mine(current_user.id).chronologic
+    when 'pending_all'
+      topics_raw = Topic.pending.chronologic if current_user.is_admin?
+    when 'closed'
+      topics_raw = Topic.closed.chronologic if current_user.is_admin?
     else
       topics_raw = topics_raw.where(current_status: @status)
     end
@@ -119,10 +123,11 @@ class Admin::BaseController < ApplicationController
     @new = topics.unread.size
     @unread = topics.unread.size
     @pending = Topic.mine(current_user.id).pending.size
+    @pending_all = topics.pending.size
     @open = topics.open.size
     @active = topics.active.size
     @mine = Topic.active.mine(current_user.id).size
-    # @closed = topics.closed.count
+    @closed = topics.closed.size
     @spam = topics.spam.size
     @trash = topics.trash.size
   end

--- a/app/views/admin/topics/_ticket_stats.html.erb
+++ b/app/views/admin/topics/_ticket_stats.html.erb
@@ -9,6 +9,8 @@
   <%= render partial: 'admin/topics/nav_item', locals: { status: 'mine', label: t(:mine), count: @mine } %>
   <%= render partial: 'admin/topics/nav_item', locals: { status: 'pending', label: t(:pending), count: @pending } %>
   <% if current_user.is_admin? %>
+    <%= render partial: 'admin/topics/nav_item', locals: { status: 'pending_all', label: t(:pending_all), count: @pending_all } %>
+    <%= render partial: 'admin/topics/nav_item', locals: { status: 'closed', label: t(:closed), count: @closed } %>
     <li>&nbsp;</li>
     <li>&nbsp;</li>
     <%= render partial: 'admin/topics/nav_item', locals: { status: 'spam', label: t(:spam), count: @spam } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -142,6 +142,7 @@ en:
   open: Open
   mine: Mine
   pending: Pending
+  pending_all: Pending (All)
   closed: &closed Closed
   spam: Spam
   trash: Trash


### PR DESCRIPTION
`Pending (All)` - pending tickets from all agents
`Closed` - closed tickets

In some cases it is useful for QA team to be able to look through
all pending and closed tickets. This functionality existed in support
pipeline view that was visible before Helpy 2.0.

Closes https://github.com/helpyio/helpy/issues/1481

@scott 