### PR TITLE
Add: capture sent to address in post

### DIFF
--- a/app/models/entity/post.rb
+++ b/app/models/entity/post.rb
@@ -13,5 +13,6 @@ module Entity
     expose :cc, documentation: { type: "String", desc: "Comma separated list of emails to CC" }
     expose :bcc, documentation: { type: "String", desc: "Comma separated list of emails to BCC" }
     expose :raw_email, documentation: { desc: "The original full raw email body" }
+    expose :email_to_address, documentation: { desc: "The address a ticket was sent to" }
   end
 end

--- a/db/migrate/20191005134018_add_email_sent_to_posts.rb
+++ b/db/migrate/20191005134018_add_email_sent_to_posts.rb
@@ -1,0 +1,5 @@
+class AddEmailSentToPosts < ActiveRecord::Migration
+  def change
+    add_column :posts, :email_to_address, :string, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190716202013) do
+ActiveRecord::Schema.define(version: 20191005134018) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -188,14 +188,15 @@ ActiveRecord::Schema.define(version: 20190716202013) do
     t.integer  "user_id"
     t.text     "body"
     t.string   "kind"
-    t.boolean  "active",      default: true
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
-    t.integer  "points",      default: 0
-    t.string   "attachments", default: [],                array: true
+    t.boolean  "active",           default: true
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
+    t.integer  "points",           default: 0
+    t.string   "attachments",      default: [],                array: true
     t.string   "cc"
     t.string   "bcc"
     t.text     "raw_email"
+    t.string   "email_to_address", default: ""
   end
 
   create_table "searches", force: :cascade do |t|

--- a/lib/email_processor.rb
+++ b/lib/email_processor.rb
@@ -118,7 +118,8 @@ class EmailProcessor
         raw_email: raw,
         user_id: @user.id,
         kind: "first",
-        cc: cc
+        cc: cc,
+        email_to_address: to
       )
       # Push array of attachments and send to Cloudinary
       EmailProcessor.handle_attachments(email, post)
@@ -167,7 +168,8 @@ class EmailProcessor
         raw_email: raw,
         user_id: @user.id,
         kind: 'first',
-        cc: cc
+        cc: cc,
+        email_to_address: to
       )
 
       # Push array of attachments and send to Cloudinary
@@ -204,7 +206,8 @@ class EmailProcessor
         raw_email: raw,
         user_id: @user.id,
         kind: "reply",
-        cc: cc
+        cc: cc,
+        email_to_address: to
       )
 
       # Push array of attachments and send to Cloudinary

--- a/test/lib/email_processor_test.rb
+++ b/test/lib/email_processor_test.rb
@@ -18,6 +18,19 @@ class EmailProcessorTest < ActiveSupport::TestCase
     end
   end
 
+  test 'an email to the support address should store the to address in the post' do
+    assert_difference('Topic.where(current_status: "new").count', 1) do
+      assert_difference('Post.count', 1) do
+        assert_difference('User.count', 1) do
+          assert_difference('ActionMailer::Base.deliveries.size', 2) do
+            EmailProcessor.new(build(:email_from_unknown)).process
+          end
+        end
+      end
+    end
+    assert_equal "to_user@email.com", Post.last.email_to_address
+  end
+
   test 'a spam email should be rejected and not create ticket, user, and should not send emails' do
     assert_difference('Topic.where(current_status: "new").count', 0) do
       assert_difference('Post.count', 0) do
@@ -127,6 +140,7 @@ class EmailProcessorTest < ActiveSupport::TestCase
         EmailProcessor.new(build(:reply)).process
       end
     end
+    assert_equal "to_user@email.com", Post.last.email_to_address
   end
 
   test 'a user should be able to reply to a ticket by email and the ticket status should change to pending' do


### PR DESCRIPTION
Adds capture of the address an email was sent to- useful for either new tickets by email channel or replies