### PR TITLE
Add placeholder, rely only on html5 url validation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 
 GIT
   remote: https://github.com/helpyio/helpy_onboarding
-  revision: dd7c96a7b9638ce089f5fac2213e15ffde2ae67b
+  revision: bb75cec5a680fdc919115b8d162be6c7863f6394
   branch: master
   specs:
     helpy_onboarding (2.0.1)

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -1,7 +1,6 @@
 class Admin::SettingsController < Admin::BaseController
 
   before_action :verify_admin, except: ['profile']
-  before_action :validate_site_url, only: :update_general
   #before_action :verify_agent, only: ['index']
   skip_before_action :verify_authenticity_token
 
@@ -199,15 +198,4 @@ class Admin::SettingsController < Admin::BaseController
     end
   end
 
-  private
-
-  def validate_site_url
-    return true if params['settings.site_url'].blank?
-
-    unless URI::regexp.match(params['settings.site_url'])
-      flash[:error] = 'The given url is invalid'
-      redirect_to admin_general_settings_path
-    end
-    true
-  end
 end

--- a/app/views/admin/settings/general.html.erb
+++ b/app/views/admin/settings/general.html.erb
@@ -13,7 +13,7 @@
 
       <h4 class="settings-subsection">Self Service Site</h4>
       <%= f.text_field 'settings.site_name', value: AppSettings['settings.site_name'], label: t('site_name', default: "Site Name") %>
-      <%= f.text_field 'settings.site_url', value: AppSettings['settings.site_url'], label: t('site_url', default: "Site URL"), pattern: '^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&\'\(\)\*\+,;=.]+$' %>
+      <%= f.text_field 'settings.site_url', value: AppSettings['settings.site_url'], label: t('site_url', default: "Site URL"), type: 'url', placeholder: t('site_url_placeholder', default: 'The URL of your Helpy (https://support.yourdomain.com)') %>
       <%= f.text_field 'settings.parent_site', value: AppSettings['settings.parent_site'], label: t('parent_site', default: "Parent Site") %>
       <%= f.text_field 'settings.parent_company', value: AppSettings['settings.parent_company'], label: t('parent_company', default: "Parent Company") %>
       <%= f.text_field 'settings.site_tagline', value: AppSettings['settings.site_tagline'], label: t('site_tagline', default: "Site Tagline") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -392,6 +392,7 @@ en:
   # General
   site_name: Site Name
   site_url: Site URL
+  site_url_placeholder: The URL of your Helpy (https://support.yourdomain.com)
   parent_site: Parent Site
   parent_company: Parent Company
   site_tagline: Site Tagline

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -59,19 +59,6 @@ class Admin::SettingsControllerTest < ActionController::TestCase
     assert_redirected_to admin_general_settings_path
   end
 
-  test 'the site url provided is invalid' do
-    sign_in users(:admin)
-    put :update_general,
-        'settings.site_name' => 'Helpy Support 2',
-        'settings.site_url' => 'invalid_url',
-        'settings.parent_site' => 'http://helpy.io/2',
-        'settings.parent_company' => 'Helpy 2',
-        'settings.site_tagline' => 'Support',
-        'settings.google_analytics_id' => 'UA-0000-21'
-    assert_equal 'The given url is invalid', flash[:error]
-    assert_redirected_to admin_general_settings_path
-  end
-
   test 'an admin should be able to modify design' do
     sign_in users(:admin)
     put :update_design,


### PR DESCRIPTION
fixes #1535 

- make sure placeholder in onboarding matches site expectation.
- remove server side validation and custom regex
- rely on html5 validation since this is really informational only.