### PR TITLE
Make file whitelist/blacklist configurable.  Use blacklist by default.

### DIFF
--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -479,6 +479,39 @@ Helpy.loader = function(){
   $('#tickets').html("<div class=\"col-md-12 text-center no-tickets\"><i class=\"fas fa-spinner fa-pulse fa-3x fa-fw\"></i><span class=\"sr-only\"></span></div>");
 };
 
+// Provides attachment validation
+Helpy.validateFiles = function (inputFile, allowedExtension, blockedExtension) {
+  var extErrorMessage, maxExceededMessage = "This file exceeds the maximum allowed file size (5 MB)";
+  if (allowedExtension.length > 0) {
+    extErrorMessage = "The following file types are allowed: " + allowedExtension;
+  } else if (blockedExtension.length > 0) {
+    extErrorMessage = "A file you attempted to upload is not allowed";
+  }
+  
+  var extName;
+  var maxFileSize = $(inputFile).data('max-file-size');
+  var sizeExceeded = false;
+  var extError = false;
+
+  $.each(inputFile.files, function () {
+    if (this.size && maxFileSize && this.size > parseInt(maxFileSize)) { sizeExceeded = true; };
+    extName = this.name.split('.').pop();
+    if (allowedExtension.length > 0 && $.inArray(extName, allowedExtension) == -1) { extError = true; };
+    if (blockedExtension.length > 0 && $.inArray(extName, blockedExtension) != -1) { extError = true; };
+  });
+  if (sizeExceeded) {
+    window.alert(maxExceededMessage);
+    $(inputFile).val('');
+  };
+
+  if (extError) {
+    window.alert(extErrorMessage);
+    $(inputFile).val('');
+  };
+}
+
+
+
 $(document).ready(Helpy.ready);
 $(document).on('page:load', Helpy.ready);
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -110,7 +110,15 @@ class TopicsController < ApplicationController
       private: params[:topic][:private],
       doc_id: params[:topic][:doc_id],
       team_list: params[:topic][:team_list],
-      channel: 'web')
+      channel: 'web'
+    )
+
+    @post = @topic.posts.new(
+      body: params[:topic][:posts_attributes]["0"][:body],
+      kind: 'first',
+      screenshots: params[:topic][:screenshots],
+      attachments: params[:topic][:posts_attributes]["0"][:attachments]
+    )
 
     associate_with_doc
 
@@ -121,29 +129,24 @@ class TopicsController < ApplicationController
       end
     end
 
-    if @topic.create_topic_with_user(params, current_user)
+    if @topic.create_topic_with_user(params, current_user, @post)
       @user = @topic.user
-      @post = @topic.posts.create(
-        :body => params[:topic][:posts_attributes]["0"][:body],
-        :user_id => @user.id,
-        :kind => 'first',
-        :screenshots => params[:topic][:screenshots],
-        :attachments => params[:topic][:posts_attributes]["0"][:attachments])
-
-      if !user_signed_in?
-        UserMailer.new_user(@user.id, @user.reset_password_token).deliver_later
-      end
+      @post.update_attribute(:user_id, @user.id)
 
       # track event in GA
       tracker('Request', 'Post', 'New Topic')
       tracker('Agent: Unassigned', 'New', @topic.to_param)
 
+      UserMailer.new_user(@user.id, @user.reset_password_token).deliver_later if !user_signed_in?
+    
       if @topic.private?
         redirect_to topic_thanks_path
       else
         redirect_to topic_posts_path(@topic)
       end
+
     else
+      set_new_page_title
       render 'new'
     end
   end
@@ -185,7 +188,10 @@ class TopicsController < ApplicationController
     @topic.posts.build #unless @topic.posts
     get_all_teams
     get_public_forums
+    set_new_page_title
+  end
 
+  def set_new_page_title
     @page_title = t(:get_help_button, default: "Open a ticket")
     add_breadcrumb @page_title
   end

--- a/app/controllers/widget/topics_controller.rb
+++ b/app/controllers/widget/topics_controller.rb
@@ -22,26 +22,25 @@ class Widget::TopicsController < Widget::BaseController
       private: params[:topic][:private],
       doc_id: params[:topic][:doc_id],
       team_list: params[:topic][:team_list],
-      channel: 'widget')
+      channel: 'widget'
+    )
+
+    @post = @topic.posts.new(
+      body: params[:topic][:posts_attributes]['0'][:body],
+      kind: 'first'
+    )
 
     @topic.private = true
 
-    if @topic.create_topic_with_user(params, current_user)
+    if @topic.create_topic_with_user(params, current_user, @post)
       @user = @topic.user
-      @post = @topic.posts.create(
-        :body => params[:topic][:posts_attributes]['0'][:body],
-        :user_id => @user.id,
-        :kind => 'first'
-        )
-
-      if !user_signed_in?
-        UserMailer.new_user(@user.id, @user.reset_password_token).deliver_later
-      end
+      @post.update_attribute(:user_id, @user.id)
 
       # track event in GA
       tracker('Request', 'Post', 'New Topic')
       tracker('Agent: Unassigned', 'New', @topic.to_param)
 
+      UserMailer.new_user(@user.id, @user.reset_password_token).deliver_later if !user_signed_in?
       redirect_to widget_thanks_path
     else
       render 'new'

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -109,4 +109,16 @@ module TopicsHelper
     content_tag(:div, '', style: badge_color_from_tag(tag_name), class: 'color-sample label-' + tag_name.first.downcase) + content_tag(:div, tag_name.try(:titleize))
   end
 
+  def extension_whitelist
+    return "" unless AppSettings['settings.extension_whitelist'].present?
+    
+    "'#{[AppSettings['settings.extension_whitelist'].split(',').map(&:strip)].join("', '")}'"
+  end
+
+  def extension_blacklist
+    return "" unless AppSettings['settings.extension_blacklist'].present?
+
+    "'#{[AppSettings['settings.extension_blacklist'].split(',').map(&:strip)].join("', '")}'".html_safe
+  end
+
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -40,7 +40,6 @@ class Post < ActiveRecord::Base
   # before_validation :truncate_body
   validates :kind, :user, :user_id, :body, presence: true
 
-
   after_create  :update_waiting_on_cache, unless: :importing
   after_create  :assign_on_reply, unless: :importing
   after_commit  :notify, on: :create, unless: :importing

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -188,13 +188,14 @@ class Topic < ActiveRecord::Base
     forum_id >= 3 && !private?
   end
 
-  def create_topic_with_user(params, current_user)
+  def create_topic_with_user(params, current_user, post)
     self.user = current_user ? current_user : User.find_by_email(params[:topic][:user][:email])
 
     unless self.user #User not found, lets build it
       self.build_user(params[:topic].require(:user).permit(:email, :name)).signup_guest
     end
-    self.user.persisted? && self.save
+    post.user = self.user
+    self.user.persisted? && self.save && post.save
   end
 
   def create_topic_with_webhook_user(params)

--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -20,37 +20,13 @@ class AttachmentUploader < CarrierWave::Uploader::Base
   def store_dir
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
-
-  # Provide a default URL as a default if there hasn't been a file uploaded:
-  # def default_url
-  #   # For Rails 3.1+ asset pipeline compatibility:
-  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
-  #
-  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
-  # end
-
-  # Process files as they are uploaded:
-  # process scale: [200, 300]
-  #
-  # def scale(width, height)
-  #   # do something
-  # end
-
-  # Create different versions of your uploaded files:
-  # version :thumb do
-  #   process resize_to_fit: [50, 50]
-  # end
-
-  # Add a white list of extensions which are allowed to be uploaded.
-  # For images you might use something like this:
-  def extension_whitelist
-    %w(jpg jpeg gif png pdf zip txt rtf doc docx xls xlsx ppt pptx)
+  
+  def extension_blacklist
+    AppSettings['settings.extension_blacklist'].split(',').map(&:strip) if AppSettings['settings.extension_blacklist'].present?
   end
 
-  # Override the filename of the uploaded files:
-  # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  # def filename
-  #   "something.jpg" if original_filename
-  # end
+  def extension_whitelist
+    AppSettings['settings.extension_whitelist'].split(',').map(&:strip) if AppSettings['settings.extension_whitelist'].present?
+  end
 
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,0 +1,9 @@
+<%= simple_form_for(@topic.posts.new, url: topic_posts_path(@topic), validate: true, method: :post, remote: true) do |f| -%>
+  <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
+  <%= f.input :body, label: I18n.t("reply", default: "Reply to this Topic"), input_html: {:rows => 8, :cols => 60, placeholder: 'Type your reply', label: I18n.t("reply", default: "Reply to this Topic"), class: 'disable-empty form-control topic-placeholder'} %>
+  <%= f.hidden_field 'kind', value: 'reply' %>
+  <%= hidden_field_tag :client_id %>
+  <%= f.attachinary_file_field :screenshots if cloudinary_enabled? %>
+  <%= f.file_field :attachments, multiple: true, onchange: 'Helpy.validateFiles(this, whitelist, blacklist);' unless cloudinary_enabled? %>				
+  <%= f.submit I18n.t('submit_reply', default: 'Post Reply'), class: 'btn btn-warning' -%>
+<% end %>

--- a/app/views/posts/create.js.erb
+++ b/app/views/posts/create.js.erb
@@ -6,4 +6,6 @@ $('.profile').initial();
 // jQuery hook
 //Helpy.ready();
 //Helpy.track();
-$('#new_post')[0].reset();
+$('#post_form').html("<%= j render(partial: 'form') %>");
+$('#new_post').enableClientSideValidations();
+$("abbr[title='required']").hide();

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,6 +1,6 @@
 <% if object.present? and object.errors.any? %>
 	<div class="alert alert-danger">
-	  <p>Please fix the errors below.</p>
+	  <p>Please fix the errors below:</p><br/>
 	  <ul class="rails-bootstrap-forms-error-summary">
 	    <% object.errors.full_messages.each do |msg| %>
 		    <li><%= msg %></li>

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -10,9 +10,9 @@
 <%- title "#{AppSettings['settings.site_name']}: #{@page_title}" %>
 
 <div class="add-form row">
-  <%= simple_form_for(@topic, validate: true) do |f| -%>
+  <%= simple_form_for(@topic, url: topics_path, validate: true, method: :post) do |f| -%>
     <div class="col-md-12">
-      <%= render 'shared/error_messages', object: f.object %>
+      <%= render 'shared/error_messages', object: @topic %>
 
       <% unless user_signed_in? %>
         <%= f.simple_fields_for @user, validate: true do |u| %>
@@ -42,6 +42,8 @@
         $(document).ready(function(){
           Helpy.showGroup();
         });
+        var whitelist = [<%= extension_whitelist.html_safe %>];
+        var blacklist = [<%= extension_blacklist.html_safe %>];
       </script>
       <% end %>
       
@@ -61,7 +63,7 @@
       <%= f.simple_fields_for :posts, validate: true do |p| %>
         <%= p.input :body, label: I18n.t(:message), input_html: {:rows => 8, :cols => 60, placeholder: I18n.t(:how_can_we_help), label: 'Message', class: 'disable-empty form-control topic-placeholder'} %>
         <% unless cloudinary_enabled? %>
-          <%= p.file_field :attachments, multiple: true%>
+          <%= p.file_field :attachments, multiple: true, onchange: "Helpy.validateFiles(this, whitelist, blacklist);" %>
           <!-- <ul class="list-inline" id="attachments"> -->
             <%#= render partial: 'posts/attachment', locals: { :model_name => @post } %>
           <!-- </ul> -->
@@ -89,9 +91,7 @@
       <!--<label>Tags:</label><br/>-->
       <%#= text_field_tag :tags %>
 
-      <%= f.submit t(:submit_start_discussion, default: 'Start Discussion'), class: 'btn btn-warning disableable', disabled: 'disabled' %>
+      <%= f.submit t(:submit_start_discussion, default: 'Start Discussion'), class: 'btn btn-warning' %>
     </div>
   <% end -%>
 </div>
-
-

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -49,7 +49,7 @@
         <%= f.text_area :body, :rows => 8, :cols => 160, skip_label: true, class: 'disable-empty' -%></p>
         <%= f.attachinary_file_field :screenshots if cloudinary_enabled? %>
         <%= f.file_field :attachments, multiple: true unless cloudinary_enabled? %>				
-        <%= f.submit I18n.t('submit_reply', default: 'Post Reply'), class: 'btn btn-warning disableable', disabled: 'disabled' -%>
+        <%= f.submit I18n.t('submit_reply', default: 'Post Reply'), class: 'btn btn-warning' -%>
       <% end -%>
       </div>
     <% end -%>

--- a/app/views/topics/ticket.html.erb
+++ b/app/views/topics/ticket.html.erb
@@ -8,7 +8,10 @@
 %>
 
 <%- title "#{AppSettings['settings.site_name']}: #{@page_title}" %>
-
+<script>
+  var whitelist = [<%= extension_whitelist.html_safe %>];
+  var blacklist = [<%= extension_blacklist.html_safe %>];
+</script>
 <div id="ticket-info" class="row">
   <div class="col-md-3 col-sm-3 hidden-xs" id="left-col-user-info">
     <div class="doc-meta">
@@ -39,18 +42,8 @@
       <%= render :partial => 'posts/post', :collection => @posts %>
     </div>
     <% if user_signed_in? %>
-      <div class="add-form">
-      <h4><%= I18n.t("reply", default: "Reply to this Topic") %></h4>
-      <%#= error_messages_for :post -%>
-      <%= bootstrap_form_for @topic.posts.new, :url => topic_posts_path(@topic), :remote => true do |f| -%>
-        <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
-        <%= f.hidden_field 'kind', value: 'reply' %>
-        <%= hidden_field_tag :client_id %>
-        <%= f.text_area :body, :rows => 8, :cols => 160, skip_label: true, class: 'disable-empty' -%></p>
-        <%= f.attachinary_file_field :screenshots if cloudinary_enabled? %>
-        <%= f.file_field :attachments, multiple: true unless cloudinary_enabled? %>				
-        <%= f.submit I18n.t('submit_reply', default: 'Post Reply'), class: 'btn btn-warning disableable', disabled: 'disabled' -%>
-      <% end -%>
+      <div class="add-form" id="post_form">
+        <%= render partial: 'posts/form' %>
       </div>
     <% end -%>
   </div>

--- a/app/views/widget/topics/new.html.erb
+++ b/app/views/widget/topics/new.html.erb
@@ -28,7 +28,7 @@
     <% end %>
 
     <%= hidden_field_tag :client_id %>
-    <%= f.submit t(:submit_start_discussion, default: 'Create Ticket'), class: 'btn btn-warning disableable', disabled: 'disabled', style: "background-color: #{AppSettings['widget.button_color']}; color: #{AppSettings['widget.button_text_color']}; border: 0" %>
+    <%= f.submit t(:submit_start_discussion, default: 'Create Ticket'), class: 'btn btn-warning', style: "background-color: #{AppSettings['widget.button_color']}; color: #{AppSettings['widget.button_text_color']}; border: 0" %>
 
   <% end -%>
   </div>

--- a/config/initializers/default_settings.rb
+++ b/config/initializers/default_settings.rb
@@ -30,6 +30,8 @@ AppSettings.defaults['settings.include_ticket_body'] = '1'
 AppSettings.defaults['settings.default_private'] = '0'
 AppSettings.defaults['settings.anonymous_access'] = '0'
 AppSettings.defaults['settings.anonymous_salt'] = 'salt'
+AppSettings.defaults['settings.extension_whitelist'] = ''
+AppSettings.defaults['settings.extension_blacklist'] = 'ade, adp, apk, appx, appxbundle, bat, cab, chm, cmd, com, cpl, dll, dmg, exe, hta, ins, isp, iso, jar, js, jse, lib, lnk, mde, msc, msi, msix, msixbundle, msp, mst, nsh, pif, ps1, scr, sct, .shb, sys, vb, vbe, vbs, vxd, wsc, wsf, wsh'
 
 # Webhook Integrations
 

--- a/test/controllers/admin/topics_controller_test.rb
+++ b/test/controllers/admin/topics_controller_test.rb
@@ -346,7 +346,7 @@ class Admin::TopicsControllerTest < ActionController::TestCase
         end
       end
 
-      assert_equal nil, Topic.last.assigned_user_id
+      assert_nil Topic.last.assigned_user_id
     end
 
     test "an #{admin} should be able to create a new private discussion for an existing user" do

--- a/test/controllers/topics_controller_test.rb
+++ b/test/controllers/topics_controller_test.rb
@@ -35,6 +35,11 @@ class TopicsControllerTest < ActionController::TestCase
     set_default_settings
   end
 
+  teardown do
+    AppSettings['settings.extension_whitelist'] = ""
+    AppSettings['settings.extension_blacklist'] = ""
+  end
+
   test 'a browsing user should get index of topics in a public forum' do
     get :index, forum_id: 3, locale: :en
     assert_not_nil assigns(:topics)
@@ -231,6 +236,74 @@ class TopicsControllerTest < ActionController::TestCase
 
     assert_equal "logo.png", Post.last.attachments.first.file.file.split("/").last
     assert_redirected_to topic_thanks_path, 'Did not redirect to thanks view'
+  end
+
+  # A new user who is NOT signed in should be able to create a new private or public topic and attach a file
+  test 'a new user should be able to create a new private topic and attach a valid file' do
+    #sign_in users(:user)
+
+    get :new, locale: :en
+    assert_response :success
+
+    assert_difference 'Topic.count', 1, 'A topic should have been created' do
+      assert_difference 'Post.count', 1, 'A post should have been created' do
+        post :create,
+          topic: {
+            user: {
+              name: 'a new user',
+              email: 'anon_new@test.com'
+              },
+            name: 'some new topic',
+            body: 'some body text',
+            forum_id: 1,
+            private: true,
+            posts_attributes: {
+              :"0" => {
+              body: "this is the body",
+              attachments: Array.wrap(uploaded_file_object(Post, :attachments, file))
+              }
+            }
+          },
+          locale: :en
+      end
+    end
+
+    assert_equal "logo.png", Post.last.attachments.first.file.file.split("/").last
+    assert_redirected_to topic_thanks_path, 'Did not redirect to thanks view'
+  end
+
+  # A new user who is NOT signed in should be able to create a new private or public topic and attach a file
+  test 'a new user should NOT be able to create a new private topic with an invalid file' do
+    #sign_in users(:user)
+    AppSettings['settings.extension_whitelist'] = "txt,doc,docx,pdf"
+
+    get :new, locale: :en
+    assert_response :success
+
+    assert_difference 'Topic.count', 0, 'A topic should NOT have been created' do
+      assert_difference 'Post.count', 0, 'A post should NOT have been created' do
+        post :create,
+          topic: {
+            user: {
+              name: 'a new user',
+              email: 'anon_new@test.com'
+              },
+            name: 'some new topic',
+            body: 'some body text',
+            forum_id: 1,
+            private: true,
+            posts_attributes: {
+              :"0" => {
+              body: "this is the body",
+              attachments: Array.wrap(uploaded_file_object(Post, :attachments, file))
+              }
+            }
+          },
+          locale: :en
+      end
+    end
+
+    assert_response :success
   end
 
 

--- a/test/integration/signed_in_user_ticket_flows_test.rb
+++ b/test/integration/signed_in_user_ticket_flows_test.rb
@@ -27,7 +27,7 @@ class SignedInUserTicketFlowsTest < ActionDispatch::IntegrationTest
       choose('Only support can respond (creates a private ticket)')
       fill_in('topic[name]', with: 'I got problems')
       fill_in('topic[posts_attributes][0][body]', with: 'Please help me!!')
-      click_on('Create Ticket', disabled: true)
+      click_on('Create Ticket')
     end
 
     visit '/en/tickets/'
@@ -50,7 +50,7 @@ class SignedInUserTicketFlowsTest < ActionDispatch::IntegrationTest
       select('Public Forum', from: "topic[forum_id]")
       fill_in('topic[name]', with: 'I got problems')
       fill_in('topic[posts_attributes][0][body]', with: 'Please help me!!')
-      click_on('Create Ticket', disabled: true)
+      click_on('Create Ticket')
     end
 
     visit '/en/community/3-public-forum/topics'
@@ -71,7 +71,7 @@ class SignedInUserTicketFlowsTest < ActionDispatch::IntegrationTest
     assert current_path == '/en/ticket/1-private-topic'
     assert_difference('Post.count', 1) do
       fill_in "post_body", with: "This is my reply"
-      click_on "Post Reply", disabled: true
+      click_on "Post Reply"
     end
 
 #    assert page.has_content?('This is my reply'), "Reply not found"
@@ -143,7 +143,7 @@ class SignedInUserTicketFlowsTest < ActionDispatch::IntegrationTest
     assert_difference('Post.count', 1) do
       fill_in('topic[name]', with: 'I got problems')
       fill_in('topic[posts_attributes][0][body]', with: 'Please help me!!')
-      click_on('Create Ticket', disabled: true)
+      click_on('Create Ticket')
     end
 
     visit '/en/tickets/'


### PR DESCRIPTION
- Adds client and server side validation for white and blacklist fails
- Can’t use white and blacklist at the same time!
- Currently only works for helpcenter, not admin