### PR TITLE
Incompatibility between grape-kaminari and ruby 2.4, works on ruby 2.5.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4
+FROM ruby:2.5
 
 ENV RAILS_ENV=production \
     HELPY_HOME=/helpy \


### PR DESCRIPTION
There's an issue when running "docker-compose up" that prevents the helpy image from building correctly due to package compatibility.

This PR simply updates the ruby version in Dockerfile to resolve the issue (as seen in #1750 )

Signed-off-by: Jordan P. Harvey <jordan@inopulse.uk>