### PR TITLE
fix readme mailto link

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Welcome, and thanks for contributing to Helpy.  Together we are building the bes
 Security Issues
 ===============
 
-If you have found a vulnerability or other security problem in Helpy, please *do not open an issue* on GitHub. Instead, contact [hello@helpy.io](mailto: hello@helpy.io) directly by email.  See the [SECURITY](/SECURITY.md) guide to learn more and see a hall of fame of security reporters.
+If you have found a vulnerability or other security problem in Helpy, please *do not open an issue* on GitHub. Instead, contact [hello@helpy.io](mailto:hello@helpy.io) directly by email.  See the [SECURITY](/SECURITY.md) guide to learn more and see a hall of fame of security reporters.
 
 License
 =======


### PR DESCRIPTION
Just a quick markdown syntax fix to correct the mailto link.