### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,3 +10,10 @@ RUN apt-get update \
   && apt-get install -y nodejs postgresql-client imagemagick --no-install-recommends \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+
+# chrome needed for running test
+# https://stackoverflow.com/a/71008100/16682649
+RUN apt-get install -y wget
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \ 
+    && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
+RUN apt-get update && apt-get -y install google-chrome-stable

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,7 +13,16 @@ RUN apt-get update \
 
 # chrome needed for running test
 # https://stackoverflow.com/a/71008100/16682649
-RUN apt-get install -y wget
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \ 
-    && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
-RUN apt-get update && apt-get -y install google-chrome-stable
+#RUN apt-get install -y wget
+#RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \ 
+#    && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
+#RUN apt-get update && apt-get -y install google-chrome-stable
+
+# https://stackoverflow.com/a/77499286/16682649
+# https://stackoverflow.com/a/78001106/31278
+# https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
+# https://chromedriver.storage.googleapis.com/
+ENV CHROME_VERSION=114.0.5735.90-1
+RUN wget -q https://mirror.cs.uchicago.edu/google-chrome/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb
+RUN apt-get -y update
+RUN apt-get install -y ./google-chrome-stable_${CHROME_VERSION}_amd64.deb

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+# Make sure RUBY_VERSION matches the Ruby version in .ruby-version
+#ARG RUBY_VERSION=3.3.3
+#FROM ghcr.io/rails/devcontainer/images/ruby:$RUBY_VERSION
+FROM ruby:2.5
+
+#RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
+#RUN apt-get install nodejs -y
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y nodejs postgresql-client imagemagick --no-install-recommends \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,13 +11,6 @@ RUN apt-get update \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-# chrome needed for running test
-# https://stackoverflow.com/a/71008100/16682649
-#RUN apt-get install -y wget
-#RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \ 
-#    && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
-#RUN apt-get update && apt-get -y install google-chrome-stable
-
 # https://stackoverflow.com/a/77499286/16682649
 # https://stackoverflow.com/a/78001106/31278
 # https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -1,0 +1,41 @@
+name: "helpy"
+
+services:
+  rails-app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+
+    volumes:
+    - ../..:/workspaces:cached
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Uncomment the next line to use a non-root user for all processes.
+    # user: vscode
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+    depends_on:
+    - selenium
+    - postgres
+
+  selenium:
+    image: selenium/standalone-chromium
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:9.4
+    restart: always
+    networks:
+    - default
+    volumes:
+    - postgres-data:/var/lib/postgresql/data
+    environment:
+        POSTGRES_USER: postgres
+        POSTGRES_PASSWORD: postgres
+
+volumes:
+  postgres-data:
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+// For format details, see https://containers.dev/implementors/json_reference/.
+// For config options, see the README at: https://github.com/devcontainers/templates/tree/main/src/ruby
+{
+	"name": "helpy",
+	"dockerComposeFile": "compose.yaml",
+	"service": "rails-app",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {
+	//   "ghcr.io/devcontainers/features/github-cli:1": {},
+	//   "ghcr.io/rails/devcontainer/features/activestorage": {},
+	//   "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+	//   "ghcr.io/rails/devcontainer/features/sqlite3": {}
+	// },
+  
+	"containerEnv": {
+	  "CAPYBARA_SERVER_PORT": "45678",
+	  "SELENIUM_HOST": "selenium",
+	  "KAMAL_REGISTRY_PASSWORD": "$KAMAL_REGISTRY_PASSWORD",
+	  "DB_HOST": "postgres"
+	},
+  
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [3000, 5432],
+  
+	// Configure tool-specific properties.
+	// "customizations": {},
+  
+	// Uncomment to connect as root instead. More info: https://containers.dev/implementors/json_reference/#remoteUser.
+	// "remoteUser": "root",
+  
+  
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "bin/setup --skip-server"
+  }
+  

--- a/Gemfile
+++ b/Gemfile
@@ -160,13 +160,13 @@ gem 'helpy_imap', git: 'https://github.com/helpyio/helpy_imap', branch: 'master'
 group :development, :test do
   # Audit Gemfile for security vulnerabilities
   gem 'bundler-audit', require: false
-  gem 'byebug'
+  gem 'byebug', '11.0'
   gem 'pry'
-  gem 'pry-byebug'
+  gem 'pry-byebug', '3.7.0'
   gem 'spring', '~> 2.0.2'
   gem 'annotate'
   gem 'brakeman', require: false
-  gem 'rubocop'
+  gem 'rubocop', '0.83.0'
   gem 'scss-lint'
   gem 'awesome_print'
   gem 'rb-readline'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     bundler-audit (0.7.0.1)
       bundler (>= 1.2.0, < 3)
       thor (>= 0.18, < 2)
-    byebug (10.0.2)
+    byebug (11.0.0)
     capybara (3.9.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -365,7 +365,7 @@ GEM
       listen (~> 2.2)
       mail (>= 2.0.3)
       maildir (>= 0.5.0)
-    method_source (1.0.0)
+    method_source (1.1.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
@@ -427,7 +427,7 @@ GEM
       activerecord (>= 3.0, < 6.0)
       activesupport (>= 3.0, < 6.0)
       request_store (~> 1.1)
-    parallel (1.19.2)
+    parallel (1.24.0)
     parser (2.7.2.0)
       ast (~> 2.4.1)
     pg (0.20.0)
@@ -442,11 +442,11 @@ GEM
     premailer-rails (1.11.1)
       actionmailer (>= 3)
       premailer (~> 1.7, >= 1.7.9)
-    pry (0.13.1)
+    pry (0.15.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.6.0)
-      byebug (~> 10.0)
+    pry-byebug (3.7.0)
+      byebug (~> 11.0)
       pry (~> 0.10)
     public_suffix (4.0.6)
     puma (5.5.0)
@@ -515,23 +515,20 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.2.4)
+    rexml (3.3.9)
     roo (2.8.3)
       nokogiri (~> 1)
       rubyzip (>= 1.3.0, < 3.0.0)
     route_translator (4.4.1)
       actionpack (>= 3.2, < 5.0)
       activesupport (>= 3.2, < 5.0)
-    rubocop (0.84.0)
+    rubocop (0.83.0)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
       rexml
-      rubocop-ast (>= 0.0.3)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (1.0.1)
-      parser (>= 2.7.1.5)
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.2)
     rubyzip (1.3.0)
@@ -607,7 +604,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
-    unicode-display_width (1.7.0)
+    unicode-display_width (1.8.0)
     unicorn (6.0.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -643,7 +640,7 @@ DEPENDENCIES
   brakeman
   bulk_insert
   bundler-audit
-  byebug
+  byebug (= 11.0)
   capybara
   capybara-email
   carrierwave (~> 1.3.1)
@@ -716,7 +713,7 @@ DEPENDENCIES
   pg_search
   premailer-rails
   pry
-  pry-byebug
+  pry-byebug (= 3.7.0)
   puma
   rack-cors
   rails (= 4.2.11.1)
@@ -729,7 +726,7 @@ DEPENDENCIES
   recaptcha (< 3)
   roo
   route_translator
-  rubocop
+  rubocop (= 0.83.0)
   sass-rails (~> 5.0.7)
   scout_apm
   scss-lint

--- a/app/controllers/api/v1/topics.rb
+++ b/app/controllers/api/v1/topics.rb
@@ -33,6 +33,8 @@ module API
               current_status: permitted_params[:status]
             )
           end
+          #binding.pry
+          params[:per_page]=1
           present paginate(topics), with: Entity::Topic
         end
 
@@ -50,6 +52,7 @@ module API
           else
             topics = Forum.find(1).topics.where(user_id: permitted_params[:user_id]).all
           end
+          params[:per_page]=1
           present paginate(topics), with: Entity::Topic
         end
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,12 +4,15 @@ default: &default
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: 5
+  host: <%= ENV["DB_HOST"] %>
+  username: postgres
+  password: postgres
 
 development:
   <<: *default
   database: helpy_development
   port: 5432
-  host: localhost
+
 
 test:
   <<: *default

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,12 +28,6 @@ ActiveRecord::Schema.define(version: 20191005134018) do
   add_index "api_keys", ["access_token"], name: "index_api_keys_on_access_token", unique: true, using: :btree
   add_index "api_keys", ["user_id"], name: "index_api_keys_on_user_id", using: :btree
 
-  create_table "ar_internal_metadata", primary_key: "key", force: :cascade do |t|
-    t.string   "value"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "attachinary_files", force: :cascade do |t|
     t.integer  "attachinariable_id"
     t.string   "attachinariable_type"
@@ -230,15 +224,8 @@ ActiveRecord::Schema.define(version: 20191005134018) do
     t.datetime "created_at"
   end
 
-  add_index "taggings", ["context"], name: "index_taggings_on_context", using: :btree
   add_index "taggings", ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true, using: :btree
-  add_index "taggings", ["tag_id"], name: "index_taggings_on_tag_id", using: :btree
   add_index "taggings", ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context", using: :btree
-  add_index "taggings", ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy", using: :btree
-  add_index "taggings", ["taggable_id"], name: "index_taggings_on_taggable_id", using: :btree
-  add_index "taggings", ["taggable_type"], name: "index_taggings_on_taggable_type", using: :btree
-  add_index "taggings", ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type", using: :btree
-  add_index "taggings", ["tagger_id"], name: "index_taggings_on_tagger_id", using: :btree
 
   create_table "tags", force: :cascade do |t|
     t.string  "name"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,7 +46,7 @@ end
 
 Capybara.register_driver :chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new(args: %w[no-sandbox headless disable-gpu --disable-dev-shm-usage])
-  Webdrivers::Chromedriver.required_version = "131.0.6778.69"
+  Webdrivers::Chromedriver.required_version = "114.0.5735.90"
   # options.binary = "/path/to/chrome/executable" 
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,7 @@ ActiveSupport::TestCase.test_order = :parallel
 require 'capybara/rails'
 require 'capybara/minitest'
 require 'capybara/email'
+require 'webdrivers'
 
 require 'minitest/retry'
 Minitest::Retry.use!
@@ -45,6 +46,8 @@ end
 
 Capybara.register_driver :chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new(args: %w[no-sandbox headless disable-gpu --disable-dev-shm-usage])
+  Webdrivers::Chromedriver.required_version = "131.0.6778.69"
+  # options.binary = "/path/to/chrome/executable" 
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 


### PR DESCRIPTION
Create a devcontainer to make development and
contribution easier.

The devcontainer is based on the Docker production image with the exception that it uses puma as
instead of nginx.

I needed to pin some of the gems that were being
used in development as they were causing issues.
Those gems were

byebug
pry-byebug
rubocop